### PR TITLE
Don't init data store with metal-api instances.

### DIFF
--- a/charts/metal-control-plane/templates/metal-api.yaml
+++ b/charts/metal-control-plane/templates/metal-api.yaml
@@ -312,16 +312,22 @@ spec:
           mountPath: /masterdata
       initContainers:
       - name: wait-for-api
-        image: gempesaw/curl-jq
+        image: {{ .Values.images.metalctl.image }}:{{ .Values.images.metalctl.tag }}
+        imagePullPolicy: {{ .Values.images.metalctl.imagePullPolicy }}
         env:
-        - name: API_BASE_URL
-          value: metal-api:{{ .Values.ports.metal_api }}{{ .Values.metal_api.base_path }}
+        - name: METALCTL_URL
+          value: http://metal-api:{{ .Values.ports.metal_api }}{{ .Values.metal_api.base_path }}
+        - name: METALCTL_HMAC
+          valueFrom:
+            secretKeyRef:
+              name: metal-api
+              key: admin_key
         command:
           - sh
           - -c
           - |
-              set -eu
-              until curl --output /dev/null --fail -s $API_BASE_URL/v1/health; do echo waiting for $API_BASE_URL; sleep 2; done
+              set -exu
+              until /metalctl partition ls; do echo "." && sleep 2; done
       volumes:
         - name: masterdata
           configMap:

--- a/charts/metal-control-plane/templates/metal-api.yaml
+++ b/charts/metal-control-plane/templates/metal-api.yaml
@@ -74,6 +74,8 @@ spec:
           value: {{ .Values.zap_encoding }}
         - name: ZAP_LEVEL
           value: {{ .Values.zap_level }}
+        - name: METAL_API_INIT_DATA_STORE
+          value: "false"
         - name: METAL_API_DB_ADDR
           value: {{ .Values.metal_api.db_address }}
         - name: METAL_API_DB_PASSWORD

--- a/charts/metal-control-plane/templates/metal-api.yaml
+++ b/charts/metal-control-plane/templates/metal-api.yaml
@@ -327,7 +327,7 @@ spec:
           - -c
           - |
               set -exu
-              until /metalctl partition ls; do echo "." && sleep 2; done
+              until /metalctl health; do echo "." && sleep 2; done
       volumes:
         - name: masterdata
           configMap:


### PR DESCRIPTION
Let only the init-db hook do the job.

References https://github.com/metal-stack/metal-api/pull/156.

Closes #9.