### PR TITLE
Use replace concurrency policy for metal-api cron jobs.

### DIFF
--- a/charts/metal-control-plane/Chart.yaml
+++ b/charts/metal-control-plane/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying the metal control plane in K8s
 name: metal-control-plane
-version: 0.3.0
+version: 0.3.1

--- a/charts/metal-control-plane/templates/metal-api.yaml
+++ b/charts/metal-control-plane/templates/metal-api.yaml
@@ -385,6 +385,7 @@ spec:
   schedule: "*/1 * * * *"
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       backoffLimit: 3
@@ -422,6 +423,7 @@ spec:
   schedule: "0 * * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       backoffLimit: 3


### PR DESCRIPTION
Prevents jobs from queuing up unnecessarily.