### PR TITLE
Only restart masterdata-api when relevant configuration changes.

### DIFF
--- a/charts/metal-control-plane/Chart.yaml
+++ b/charts/metal-control-plane/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying the metal control plane in K8s
 name: metal-control-plane
-version: 0.3.6
+version: 0.3.7

--- a/charts/metal-control-plane/templates/masterdata-api-config.yaml
+++ b/charts/metal-control-plane/templates/masterdata-api-config.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-tenant
+data:
+  tenant.yaml: |
+    {{ .Values.masterdata_api.tenants | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-project
+data:
+  project.yaml: |
+    {{ .Values.masterdata_api.projects | nindent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: masterdata-api-tls
+type: Opaque
+data:
+  ca.pem: {{ .Values.masterdata_api.ca }}
+  client.pem: {{ .Values.masterdata_api.client_cert }}
+  client-key.pem: {{ .Values.masterdata_api.client_key }}
+  server-key.pem: {{ .Values.masterdata_api.cert_key }}
+  server.pem: {{ .Values.masterdata_api.cert }}

--- a/charts/metal-control-plane/templates/masterdata-api.yaml
+++ b/charts/metal-control-plane/templates/masterdata-api.yaml
@@ -1,32 +1,4 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: default-tenant
-data:
-  tenant.yaml: |
-    {{ .Values.masterdata_api.tenants | nindent 4 }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: default-project
-data:
-  project.yaml: |
-    {{ .Values.masterdata_api.projects | nindent 4 }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: masterdata-api-tls
-type: Opaque
-data:
-  ca.pem: {{ .Values.masterdata_api.ca }}
-  client.pem: {{ .Values.masterdata_api.client_cert }}
-  client-key.pem: {{ .Values.masterdata_api.client_key }}
-  server-key.pem: {{ .Values.masterdata_api.cert_key }}
-  server.pem: {{ .Values.masterdata_api.cert }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,10 +11,8 @@ spec:
     metadata:
       labels:
         app: masterdata-api
-{{- if .Values.helm_chart }}
-        ansible_config_hash: {{ .Values.helm_chart.config_hash }}
-{{- end }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/masterdata-api-config.yaml") . | sha256sum }}
         prometheus.io/scrape: 'true'
         prometheus.io/path: /metrics
         prometheus.io/port: '2112'


### PR DESCRIPTION
With this approach we make the masterdata-api only restart if configuration relevant for this component changes and not when there is a change in the rest of the config, too.