### PR TITLE
Revert "Fix variable in template"

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/postgreslet/templates/configmap.yaml
+++ b/charts/postgreslet/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   LOAD_BALANCER_IP: {{ .Values.postgreslet.loadBalancerIP | quote }}
   PORT_RANGE_START: {{ .Values.postgreslet.portRangeStart | quote }}
   PORT_RANGE_SIZE: {{ .Values.postgreslet.portRangeSize | quote }}
-  CUSTOM_PSP_NAME: {{ .Values.postgreslet.customPspName | quote  }}
+  CUSTOM_PSP_NAME: {{ include "postgreslet.pspName" . | quote  }}
   STORAGE_CLASS: {{ .Values.postgreslet.storageClass | quote  }}
   OPERATOR_IMAGE: {{ .Values.postgreslet.operatorImage | quote  }}
   POSTGRES_IMAGE: {{ .Values.postgreslet.postgresImage | quote  }}


### PR DESCRIPTION
This reverts commit 4c323c5431e8eedcb7ffe3d4e061dda15045ef6d.

Using the helper variable again, as it falls back to the helm release name if that `customPspName` is not set.

This caused some troubles as the operator falls back to the default psp name, which was present on shared clusters where the operator was installed manually or via ansible, but was not present where the postgreslet was insatlled via this helm chart (as it installs that psp under another name).