### PR TITLE
Custom CRD for standby clusters and additional params

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2

--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3

--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1

--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0

--- a/charts/postgreslet/crds/postgresql.yaml
+++ b/charts/postgreslet/crds/postgresql.yaml
@@ -1,490 +1,532 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    helm.sh/hook: crd-install
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition","metadata":{"annotations":{"helm.sh/hook":"crd-install"},"labels":{"app.kubernetes.io/name":"postgres-operator"},"name":"postgresqls.acid.zalan.do"},"spec":{"group":"acid.zalan.do","names":{"categories":["all"],"kind":"postgresql","listKind":"postgresqlList","plural":"postgresqls","shortNames":["pg"],"singular":"postgresql"},"scope":"Namespaced","versions":[{"additionalPrinterColumns":[{"description":"Team responsible for Postgres CLuster","jsonPath":".spec.teamId","name":"Team","type":"string"},{"description":"PostgreSQL version","jsonPath":".spec.postgresql.version","name":"Version","type":"string"},{"description":"Number of Pods per Postgres cluster","jsonPath":".spec.numberOfInstances","name":"Pods","type":"integer"},{"description":"Size of the bound volume","jsonPath":".spec.volume.size","name":"Volume","type":"string"},{"description":"Requested CPU for Postgres containers","jsonPath":".spec.resources.requests.cpu","name":"CPU-Request","type":"string"},{"description":"Requested memory for Postgres containers","jsonPath":".spec.resources.requests.memory","name":"Memory-Request","type":"string"},{"jsonPath":".metadata.creationTimestamp","name":"Age","type":"date"},{"description":"Current sync status of postgresql resource","jsonPath":".status.PostgresClusterStatus","name":"Status","type":"string"}],"name":"v1","schema":{"openAPIV3Schema":{"properties":{"apiVersion":{"enum":["acid.zalan.do/v1"],"type":"string"},"kind":{"enum":["postgresql"],"type":"string"},"spec":{"properties":{"additionalVolumes":{"items":{"properties":{"mountPath":{"type":"string"},"name":{"type":"string"},"subPath":{"type":"string"},"targetContainers":{"items":{"type":"string"},"nullable":true,"type":"array"},"volumeSource":{"type":"object","x-kubernetes-preserve-unknown-fields":true}},"required":["name","mountPath","volumeSource"],"type":"object"},"type":"array"},"allowedSourceRanges":{"items":{"pattern":"^(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\/(\\d|[1-2]\\d|3[0-2])$","type":"string"},"nullable":true,"type":"array"},"clone":{"properties":{"cluster":{"type":"string"},"s3_access_key_id":{"type":"string"},"s3_endpoint":{"type":"string"},"s3_force_path_style":{"type":"boolean"},"s3_secret_access_key":{"type":"string"},"s3_wal_path":{"type":"string"},"timestamp":{"pattern":"^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$","type":"string"},"uid":{"format":"uuid","type":"string"}},"required":["cluster"],"type":"object"},"connectionPooler":{"properties":{"dockerImage":{"type":"string"},"maxDBConnections":{"type":"integer"},"mode":{"enum":["session","transaction"],"type":"string"},"numberOfInstances":{"minimum":2,"type":"integer"},"resources":{"properties":{"limits":{"properties":{"cpu":{"pattern":"^(\\d+m|\\d+(\\.\\d{1,3})?)$","type":"string"},"memory":{"pattern":"^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$","type":"string"}},"required":["cpu","memory"],"type":"object"},"requests":{"properties":{"cpu":{"pattern":"^(\\d+m|\\d+(\\.\\d{1,3})?)$","type":"string"},"memory":{"pattern":"^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$","type":"string"}},"required":["cpu","memory"],"type":"object"}},"required":["requests","limits"],"type":"object"},"schema":{"type":"string"},"user":{"type":"string"}},"type":"object"},"databases":{"additionalProperties":{"type":"string"},"type":"object"},"dockerImage":{"type":"string"},"enableConnectionPooler":{"type":"boolean"},"enableLogicalBackup":{"type":"boolean"},"enableMasterLoadBalancer":{"type":"boolean"},"enableReplicaConnectionPooler":{"type":"boolean"},"enableReplicaLoadBalancer":{"type":"boolean"},"enableShmVolume":{"type":"boolean"},"initContainers":{"items":{"type":"object","x-kubernetes-preserve-unknown-fields":true},"nullable":true,"type":"array"},"init_containers":{"items":{"type":"object","x-kubernetes-preserve-unknown-fields":true},"nullable":true,"type":"array"},"logicalBackupSchedule":{"pattern":"^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$","type":"string"},"maintenanceWindows":{"items":{"pattern":"^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$","type":"string"},"type":"array"},"nodeAffinity":{"properties":{"preferredDuringSchedulingIgnoredDuringExecution":{"items":{"properties":{"preference":{"properties":{"matchExpressions":{"items":{"properties":{"key":{"type":"string"},"operator":{"type":"string"},"values":{"items":{"type":"string"},"type":"array"}},"required":["key","operator"],"type":"object"},"type":"array"},"matchFields":{"items":{"properties":{"key":{"type":"string"},"operator":{"type":"string"},"values":{"items":{"type":"string"},"type":"array"}},"required":["key","operator"],"type":"object"},"type":"array"}},"type":"object"},"weight":{"format":"int32","type":"integer"}},"required":["weight","preference"],"type":"object"},"type":"array"},"requiredDuringSchedulingIgnoredDuringExecution":{"properties":{"nodeSelectorTerms":{"items":{"properties":{"matchExpressions":{"items":{"properties":{"key":{"type":"string"},"operator":{"type":"string"},"values":{"items":{"type":"string"},"type":"array"}},"required":["key","operator"],"type":"object"},"type":"array"},"matchFields":{"items":{"properties":{"key":{"type":"string"},"operator":{"type":"string"},"values":{"items":{"type":"string"},"type":"array"}},"required":["key","operator"],"type":"object"},"type":"array"}},"type":"object"},"type":"array"}},"required":["nodeSelectorTerms"],"type":"object"}},"type":"object"},"numberOfInstances":{"minimum":0,"type":"integer"},"patroni":{"properties":{"initdb":{"additionalProperties":{"type":"string"},"type":"object"},"loop_wait":{"type":"integer"},"maximum_lag_on_failover":{"type":"integer"},"pg_hba":{"items":{"type":"string"},"type":"array"},"retry_timeout":{"type":"integer"},"slots":{"additionalProperties":{"additionalProperties":{"type":"string"},"type":"object"},"type":"object"},"synchronous_mode":{"type":"boolean"},"synchronous_mode_strict":{"type":"boolean"},"ttl":{"type":"integer"}},"type":"object"},"podAnnotations":{"additionalProperties":{"type":"string"},"type":"object"},"podPriorityClassName":{"type":"string"},"pod_priority_class_name":{"type":"string"},"postgresql":{"properties":{"parameters":{"additionalProperties":{"type":"string"},"type":"object"},"version":{"enum":["9.3","9.4","9.5","9.6","10","11","12","13"],"type":"string"}},"required":["version"],"type":"object"},"preparedDatabases":{"additionalProperties":{"properties":{"defaultUsers":{"type":"boolean"},"extensions":{"additionalProperties":{"type":"string"},"type":"object"},"schemas":{"additionalProperties":{"properties":{"defaultRoles":{"type":"boolean"},"defaultUsers":{"type":"boolean"}},"type":"object"},"type":"object"}},"type":"object"},"type":"object"},"replicaLoadBalancer":{"type":"boolean"},"resources":{"properties":{"limits":{"properties":{"cpu":{"pattern":"^(\\d+m|\\d+(\\.\\d{1,3})?)$","type":"string"},"memory":{"pattern":"^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$","type":"string"}},"required":["cpu","memory"],"type":"object"},"requests":{"properties":{"cpu":{"pattern":"^(\\d+m|\\d+(\\.\\d{1,3})?)$","type":"string"},"memory":{"pattern":"^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$","type":"string"}},"required":["cpu","memory"],"type":"object"}},"required":["requests","limits"],"type":"object"},"schedulerName":{"type":"string"},"serviceAnnotations":{"additionalProperties":{"type":"string"},"type":"object"},"sidecars":{"items":{"type":"object","x-kubernetes-preserve-unknown-fields":true},"nullable":true,"type":"array"},"spiloFSGroup":{"type":"integer"},"spiloRunAsGroup":{"type":"integer"},"spiloRunAsUser":{"type":"integer"},"standby":{"properties":{"s3_wal_path":{"type":"string"}},"required":["s3_wal_path"],"type":"object"},"teamId":{"type":"string"},"tls":{"properties":{"caFile":{"type":"string"},"caSecretName":{"type":"string"},"certificateFile":{"type":"string"},"privateKeyFile":{"type":"string"},"secretName":{"type":"string"}},"required":["secretName"],"type":"object"},"tolerations":{"items":{"properties":{"effect":{"enum":["NoExecute","NoSchedule","PreferNoSchedule"],"type":"string"},"key":{"type":"string"},"operator":{"enum":["Equal","Exists"],"type":"string"},"tolerationSeconds":{"type":"integer"},"value":{"type":"string"}},"required":["key","operator","effect"],"type":"object"},"type":"array"},"useLoadBalancer":{"type":"boolean"},"users":{"additionalProperties":{"description":"Role flags specified here must not contradict each other","items":{"enum":["bypassrls","BYPASSRLS","nobypassrls","NOBYPASSRLS","createdb","CREATEDB","nocreatedb","NOCREATEDB","createrole","CREATEROLE","nocreaterole","NOCREATEROLE","inherit","INHERIT","noinherit","NOINHERIT","login","LOGIN","nologin","NOLOGIN","replication","REPLICATION","noreplication","NOREPLICATION","superuser","SUPERUSER","nosuperuser","NOSUPERUSER"],"type":"string"},"nullable":true,"type":"array"},"type":"object"},"volume":{"properties":{"iops":{"type":"integer"},"size":{"pattern":"^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$","type":"string"},"storageClass":{"type":"string"},"subPath":{"type":"string"},"throughput":{"type":"integer"}},"required":["size"],"type":"object"}},"required":["numberOfInstances","teamId","postgresql","volume"],"type":"object"},"status":{"additionalProperties":{"type":"string"},"type":"object"}},"required":["kind","apiVersion","spec"],"type":"object"}},"served":true,"storage":true,"subresources":{"status":{}}}]}}
-  labels:
-    app.kubernetes.io/name: postgres-operator
   name: postgresqls.acid.zalan.do
 spec:
   group: acid.zalan.do
   names:
-    categories:
-    - all
     kind: postgresql
     listKind: postgresqlList
     plural: postgresqls
+    singular: postgresql
     shortNames:
     - pg
-    singular: postgresql
+    categories:
+    - all
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Team responsible for Postgres CLuster
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Team
+      type: string
+      description: Team responsible for Postgres CLuster
       jsonPath: .spec.teamId
-      name: Team
+    - name: Version
       type: string
-    - description: PostgreSQL version
+      description: PostgreSQL version
       jsonPath: .spec.postgresql.version
-      name: Version
-      type: string
-    - description: Number of Pods per Postgres cluster
-      jsonPath: .spec.numberOfInstances
-      name: Pods
+    - name: Pods
       type: integer
-    - description: Size of the bound volume
+      description: Number of Pods per Postgres cluster
+      jsonPath: .spec.numberOfInstances
+    - name: Volume
+      type: string
+      description: Size of the bound volume
       jsonPath: .spec.volume.size
-      name: Volume
+    - name: CPU-Request
       type: string
-    - description: Requested CPU for Postgres containers
+      description: Requested CPU for Postgres containers
       jsonPath: .spec.resources.requests.cpu
-      name: CPU-Request
+    - name: Memory-Request
       type: string
-    - description: Requested memory for Postgres containers
+      description: Requested memory for Postgres containers
       jsonPath: .spec.resources.requests.memory
-      name: Memory-Request
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
+    - name: Age
       type: date
-    - description: Current sync status of postgresql resource
-      jsonPath: .status.PostgresClusterStatus
-      name: Status
+      jsonPath: .metadata.creationTimestamp
+    - name: Status
       type: string
-    name: v1
+      description: Current sync status of postgresql resource
+      jsonPath: .status.PostgresClusterStatus
     schema:
       openAPIV3Schema:
+        type: object
+        required:
+          - kind
+          - apiVersion
+          - spec
         properties:
-          apiVersion:
-            enum:
-            - acid.zalan.do/v1
-            type: string
           kind:
-            enum:
-            - postgresql
             type: string
+            enum:
+              - postgresql
+          apiVersion:
+            type: string
+            enum:
+              - acid.zalan.do/v1
           spec:
+            type: object
+            required:
+              - numberOfInstances
+              - teamId
+              - postgresql
+              - volume
             properties:
               additionalVolumes:
+                type: array
                 items:
+                  type: object
+                  required:
+                    - name
+                    - mountPath
+                    - volumeSource
                   properties:
-                    mountPath:
-                      type: string
                     name:
                       type: string
-                    subPath:
+                    mountPath:
                       type: string
                     targetContainers:
+                      type: array
+                      nullable: true
                       items:
                         type: string
-                      nullable: true
-                      type: array
                     volumeSource:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                  required:
-                  - name
-                  - mountPath
-                  - volumeSource
-                  type: object
-                type: array
+                    subPath:
+                      type: string
               allowedSourceRanges:
-                items:
-                  pattern: ^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\/(\d|[1-2]\d|3[0-2])$
-                  type: string
-                nullable: true
                 type: array
+                nullable: true
+                items:
+                  type: string
+                  pattern: '^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\/(\d|[1-2]\d|3[0-2])$'
               clone:
+                type: object
+                required:
+                  - cluster
                 properties:
                   cluster:
                     type: string
+                  s3_endpoint:
+                    type: string
                   s3_access_key_id:
                     type: string
-                  s3_endpoint:
+                  s3_secret_access_key:
                     type: string
                   s3_force_path_style:
                     type: boolean
-                  s3_secret_access_key:
-                    type: string
                   s3_wal_path:
                     type: string
                   timestamp:
-                    pattern: ^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$
                     type: string
+                    pattern: '^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$'
+                    # The regexp matches the date-time format (RFC 3339 Section 5.6) that specifies a timezone as an offset relative to UTC
+                    # Example: 1996-12-19T16:39:57-08:00
+                    # Note: this field requires a timezone
                   uid:
                     format: uuid
                     type: string
-                required:
-                - cluster
-                type: object
               connectionPooler:
+                type: object
                 properties:
                   dockerImage:
                     type: string
                   maxDBConnections:
                     type: integer
                   mode:
-                    enum:
-                    - session
-                    - transaction
                     type: string
+                    enum:
+                      - "session"
+                      - "transaction"
                   numberOfInstances:
-                    minimum: 2
                     type: integer
+                    minimum: 2
                   resources:
+                    type: object
+                    required:
+                      - requests
+                      - limits
                     properties:
                       limits:
+                        type: object
+                        required:
+                          - cpu
+                          - memory
                         properties:
                           cpu:
-                            pattern: ^(\d+m|\d+(\.\d{1,3})?)$
                             type: string
+                            pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                           memory:
-                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
                             type: string
-                        required:
-                        - cpu
-                        - memory
-                        type: object
+                            pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                       requests:
+                        type: object
+                        required:
+                          - cpu
+                          - memory
                         properties:
                           cpu:
-                            pattern: ^(\d+m|\d+(\.\d{1,3})?)$
                             type: string
+                            pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                           memory:
-                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
                             type: string
-                        required:
-                        - cpu
-                        - memory
-                        type: object
-                    required:
-                    - requests
-                    - limits
-                    type: object
+                            pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                   schema:
                     type: string
                   user:
                     type: string
-                type: object
               databases:
+                type: object
                 additionalProperties:
                   type: string
-                type: object
+                # Note: usernames specified here as database owners must be declared in the users key of the spec key.
               dockerImage:
                 type: string
               enableConnectionPooler:
+                type: boolean
+              enableReplicaConnectionPooler:
                 type: boolean
               enableLogicalBackup:
                 type: boolean
               enableMasterLoadBalancer:
                 type: boolean
-              enableReplicaConnectionPooler:
-                type: boolean
               enableReplicaLoadBalancer:
                 type: boolean
               enableShmVolume:
                 type: boolean
-              init_containers:
+              init_containers:  # deprecated
+                type: array
+                nullable: true
                 items:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                nullable: true
-                type: array
               initContainers:
+                type: array
+                nullable: true
                 items:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                nullable: true
-                type: array
               logicalBackupSchedule:
-                pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
                 type: string
+                pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
               maintenanceWindows:
-                items:
-                  pattern: ^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\
-                    *$
-                  type: string
                 type: array
-              nodeAffinity:
-                properties:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                    items:
-                      properties:
-                        preference:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchFields:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      required:
-                      - weight
-                      - preference
-                      type: object
-                    type: array
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    properties:
-                      nodeSelectorTerms:
-                        items:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchFields:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    required:
-                    - nodeSelectorTerms
-                    type: object
-                type: object
+                items:
+                  type: string
+                  pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
               numberOfInstances:
-                minimum: 0
                 type: integer
+                minimum: 0
               patroni:
+                type: object
                 properties:
                   initdb:
+                    type: object
                     additionalProperties:
                       type: string
-                    type: object
                   loop_wait:
                     type: integer
                   maximum_lag_on_failover:
                     type: integer
                   pg_hba:
+                    type: array
                     items:
                       type: string
-                    type: array
                   retry_timeout:
                     type: integer
                   slots:
+                    type: object
                     additionalProperties:
+                      type: object
                       additionalProperties:
                         type: string
-                      type: object
-                    type: object
                   synchronous_mode:
                     type: boolean
                   synchronous_mode_strict:
                     type: boolean
                   ttl:
                     type: integer
-                type: object
-              pod_priority_class_name:
-                type: string
               podAnnotations:
+                type: object
                 additionalProperties:
                   type: string
-                type: object
+              pod_priority_class_name:  # deprecated
+                type: string
               podPriorityClassName:
                 type: string
               postgresql:
+                type: object
+                required:
+                  - version
                 properties:
+                  version:
+                    type: string
+                    enum:
+                      - "9.3"
+                      - "9.4"
+                      - "9.5"
+                      - "9.6"
+                      - "10"
+                      - "11"
+                      - "12"
+                      - "13"
                   parameters:
+                    type: object
                     additionalProperties:
                       type: string
-                    type: object
-                  version:
-                    enum:
-                    - "9.3"
-                    - "9.4"
-                    - "9.5"
-                    - "9.6"
-                    - "10"
-                    - "11"
-                    - "12"
-                    - "13"
-                    type: string
-                required:
-                - version
-                type: object
               preparedDatabases:
+                type: object
                 additionalProperties:
+                  type: object
                   properties:
                     defaultUsers:
                       type: boolean
                     extensions:
+                      type: object
                       additionalProperties:
                         type: string
-                      type: object
                     schemas:
+                      type: object
                       additionalProperties:
+                        type: object
                         properties:
-                          defaultRoles:
-                            type: boolean
                           defaultUsers:
                             type: boolean
-                        type: object
-                      type: object
-                  type: object
-                type: object
-              replicaLoadBalancer:
+                          defaultRoles:
+                            type: boolean
+              replicaLoadBalancer:  # deprecated
                 type: boolean
               resources:
+                type: object
+                required:
+                  - requests
+                  - limits
                 properties:
                   limits:
+                    type: object
+                    required:
+                      - cpu
+                      - memory
                     properties:
                       cpu:
-                        pattern: ^(\d+m|\d+(\.\d{1,3})?)$
                         type: string
+                        # Decimal natural followed by m, or decimal natural followed by
+                        # dot followed by up to three decimal digits.
+                        #
+                        # This is because the Kubernetes CPU resource has millis as the
+                        # maximum precision.  The actual values are checked in code
+                        # because the regular expression would be huge and horrible and
+                        # not very helpful in validation error messages; this one checks
+                        # only the format of the given number.
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                        # Note: the value specified here must not be zero or be lower
+                        # than the corresponding request.
                       memory:
-                        pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
                         type: string
-                    required:
-                    - cpu
-                    - memory
-                    type: object
+                        # You can express memory as a plain integer or as a fixed-point
+                        # integer using one of these suffixes: E, P, T, G, M, k. You can
+                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                        # Note: the value specified here must not be zero or be higher
+                        # than the corresponding limit.
                   requests:
+                    type: object
+                    required:
+                      - cpu
+                      - memory
                     properties:
                       cpu:
-                        pattern: ^(\d+m|\d+(\.\d{1,3})?)$
                         type: string
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                       memory:
-                        pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
                         type: string
-                    required:
-                    - cpu
-                    - memory
-                    type: object
-                required:
-                - requests
-                - limits
-                type: object
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
               schedulerName:
                 type: string
               serviceAnnotations:
+                type: object
                 additionalProperties:
                   type: string
-                type: object
               sidecars:
+                type: array
+                nullable: true
                 items:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                nullable: true
-                type: array
-              spiloFSGroup:
+              spiloRunAsUser:
                 type: integer
               spiloRunAsGroup:
                 type: integer
-              spiloRunAsUser:
+              spiloFSGroup:
                 type: integer
               standby:
+                type: object
+                required:
+                  - standby_method
                 properties:
                   s3_wal_path:
                     type: string
-                required:
-                - s3_wal_path
-                type: object
+                  standby_host:
+                    type: string
+                  standby_method:
+                    type: string
+                  standby_port:
+                    type: string
+                  standby_secret_name:
+                    type: string
               teamId:
                 type: string
               tls:
+                type: object
+                required:
+                  - secretName
                 properties:
-                  caFile:
-                    type: string
-                  caSecretName:
+                  secretName:
                     type: string
                   certificateFile:
                     type: string
                   privateKeyFile:
                     type: string
-                  secretName:
+                  caFile:
                     type: string
-                required:
-                - secretName
+                  caSecretName:
+                    type: string
+              nodeAffinity:
                 type: object
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - weight
+                      - preference
+                      properties:
+                        preference:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                        weight:
+                          format: int32
+                          type: integer
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    type: object
+                    required:
+                    - nodeSelectorTerms
+                    properties:
+                      nodeSelectorTerms:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
               tolerations:
+                type: array
                 items:
+                  type: object
+                  required:
+                    - key
+                    - operator
+                    - effect
                   properties:
-                    effect:
-                      enum:
-                      - NoExecute
-                      - NoSchedule
-                      - PreferNoSchedule
-                      type: string
                     key:
                       type: string
                     operator:
-                      enum:
-                      - Equal
-                      - Exists
                       type: string
-                    tolerationSeconds:
-                      type: integer
+                      enum:
+                        - Equal
+                        - Exists
                     value:
                       type: string
-                  required:
-                  - key
-                  - operator
-                  - effect
-                  type: object
-                type: array
-              useLoadBalancer:
+                    effect:
+                      type: string
+                      enum:
+                        - NoExecute
+                        - NoSchedule
+                        - PreferNoSchedule
+                    tolerationSeconds:
+                      type: integer
+              useLoadBalancer:  # deprecated
                 type: boolean
               users:
+                type: object
                 additionalProperties:
-                  description: Role flags specified here must not contradict each
-                    other
+                  type: array
+                  nullable: true
+                  description: "Role flags specified here must not contradict each other"
                   items:
+                    type: string
                     enum:
                     - bypassrls
                     - BYPASSRLS
@@ -514,42 +556,20 @@ spec:
                     - SUPERUSER
                     - nosuperuser
                     - NOSUPERUSER
-                    type: string
-                  nullable: true
-                  type: array
-                type: object
               volume:
+                type: object
+                required:
+                  - size
                 properties:
-                  iops:
-                    type: integer
                   size:
-                    pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
                     type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    # Note: the value specified here must not be zero.
                   storageClass:
                     type: string
                   subPath:
                     type: string
-                  throughput:
-                    type: integer
-                required:
-                - size
-                type: object
-            required:
-            - numberOfInstances
-            - teamId
-            - postgresql
-            - volume
-            type: object
           status:
+            type: object
             additionalProperties:
               type: string
-            type: object
-        required:
-        - kind
-        - apiVersion
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}

--- a/charts/postgreslet/crds/postgresql.yaml
+++ b/charts/postgreslet/crds/postgresql.yaml
@@ -23,7 +23,7 @@ spec:
     additionalPrinterColumns:
     - name: Team
       type: string
-      description: Team responsible for Postgres CLuster
+      description: Team responsible for Postgres cluster
       jsonPath: .spec.teamId
     - name: Version
       type: string
@@ -219,187 +219,6 @@ spec:
                 items:
                   type: string
                   pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
-              numberOfInstances:
-                type: integer
-                minimum: 0
-              patroni:
-                type: object
-                properties:
-                  initdb:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  loop_wait:
-                    type: integer
-                  maximum_lag_on_failover:
-                    type: integer
-                  pg_hba:
-                    type: array
-                    items:
-                      type: string
-                  retry_timeout:
-                    type: integer
-                  slots:
-                    type: object
-                    additionalProperties:
-                      type: object
-                      additionalProperties:
-                        type: string
-                  synchronous_mode:
-                    type: boolean
-                  synchronous_mode_strict:
-                    type: boolean
-                  ttl:
-                    type: integer
-              podAnnotations:
-                type: object
-                additionalProperties:
-                  type: string
-              pod_priority_class_name:  # deprecated
-                type: string
-              podPriorityClassName:
-                type: string
-              postgresql:
-                type: object
-                required:
-                  - version
-                properties:
-                  version:
-                    type: string
-                    enum:
-                      - "9.3"
-                      - "9.4"
-                      - "9.5"
-                      - "9.6"
-                      - "10"
-                      - "11"
-                      - "12"
-                      - "13"
-                  parameters:
-                    type: object
-                    additionalProperties:
-                      type: string
-              preparedDatabases:
-                type: object
-                additionalProperties:
-                  type: object
-                  properties:
-                    defaultUsers:
-                      type: boolean
-                    extensions:
-                      type: object
-                      additionalProperties:
-                        type: string
-                    schemas:
-                      type: object
-                      additionalProperties:
-                        type: object
-                        properties:
-                          defaultUsers:
-                            type: boolean
-                          defaultRoles:
-                            type: boolean
-              replicaLoadBalancer:  # deprecated
-                type: boolean
-              resources:
-                type: object
-                required:
-                  - requests
-                  - limits
-                properties:
-                  limits:
-                    type: object
-                    required:
-                      - cpu
-                      - memory
-                    properties:
-                      cpu:
-                        type: string
-                        # Decimal natural followed by m, or decimal natural followed by
-                        # dot followed by up to three decimal digits.
-                        #
-                        # This is because the Kubernetes CPU resource has millis as the
-                        # maximum precision.  The actual values are checked in code
-                        # because the regular expression would be huge and horrible and
-                        # not very helpful in validation error messages; this one checks
-                        # only the format of the given number.
-                        #
-                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
-                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
-                        # Note: the value specified here must not be zero or be lower
-                        # than the corresponding request.
-                      memory:
-                        type: string
-                        # You can express memory as a plain integer or as a fixed-point
-                        # integer using one of these suffixes: E, P, T, G, M, k. You can
-                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
-                        #
-                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
-                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
-                        # Note: the value specified here must not be zero or be higher
-                        # than the corresponding limit.
-                  requests:
-                    type: object
-                    required:
-                      - cpu
-                      - memory
-                    properties:
-                      cpu:
-                        type: string
-                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
-                      memory:
-                        type: string
-                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
-              schedulerName:
-                type: string
-              serviceAnnotations:
-                type: object
-                additionalProperties:
-                  type: string
-              sidecars:
-                type: array
-                nullable: true
-                items:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-              spiloRunAsUser:
-                type: integer
-              spiloRunAsGroup:
-                type: integer
-              spiloFSGroup:
-                type: integer
-              standby:
-                type: object
-                required:
-                  - standby_method
-                properties:
-                  s3_wal_path:
-                    type: string
-                  standby_host:
-                    type: string
-                  standby_method:
-                    type: string
-                  standby_port:
-                    type: string
-                  standby_secret_name:
-                    type: string
-              teamId:
-                type: string
-              tls:
-                type: object
-                required:
-                  - secretName
-                properties:
-                  secretName:
-                    type: string
-                  certificateFile:
-                    type: string
-                  privateKeyFile:
-                    type: string
-                  caFile:
-                    type: string
-                  caSecretName:
-                    type: string
               nodeAffinity:
                 type: object
                 properties:
@@ -491,6 +310,188 @@ spec:
                                     type: array
                                     items:
                                       type: string
+              numberOfInstances:
+                type: integer
+                minimum: 0
+              patroni:
+                type: object
+                properties:
+                  initdb:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  loop_wait:
+                    type: integer
+                  maximum_lag_on_failover:
+                    type: integer
+                  pg_hba:
+                    type: array
+                    items:
+                      type: string
+                  retry_timeout:
+                    type: integer
+                  slots:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      additionalProperties:
+                        type: string
+                  synchronous_mode:
+                    type: boolean
+                  synchronous_mode_strict:
+                    type: boolean
+                  ttl:
+                    type: integer
+              podAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              pod_priority_class_name:  # deprecated
+                type: string
+              podPriorityClassName:
+                type: string
+              postgresql:
+                type: object
+                required:
+                  - version
+                properties:
+                  version:
+                    type: string
+                    enum:
+                      - "9.5"
+                      - "9.6"
+                      - "10"
+                      - "11"
+                      - "12"
+                      - "13"
+                      - "14"
+                  parameters:
+                    type: object
+                    additionalProperties:
+                      type: string
+              preparedDatabases:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    defaultUsers:
+                      type: boolean
+                    extensions:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    schemas:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          defaultUsers:
+                            type: boolean
+                          defaultRoles:
+                            type: boolean
+                    secretNamespace:
+                      type: string
+              replicaLoadBalancer:  # deprecated
+                type: boolean
+              resources:
+                type: object
+                required:
+                  - requests
+                  - limits
+                properties:
+                  limits:
+                    type: object
+                    required:
+                      - cpu
+                      - memory
+                    properties:
+                      cpu:
+                        type: string
+                        # Decimal natural followed by m, or decimal natural followed by
+                        # dot followed by up to three decimal digits.
+                        #
+                        # This is because the Kubernetes CPU resource has millis as the
+                        # maximum precision.  The actual values are checked in code
+                        # because the regular expression would be huge and horrible and
+                        # not very helpful in validation error messages; this one checks
+                        # only the format of the given number.
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                        # Note: the value specified here must not be zero or be lower
+                        # than the corresponding request.
+                      memory:
+                        type: string
+                        # You can express memory as a plain integer or as a fixed-point
+                        # integer using one of these suffixes: E, P, T, G, M, k. You can
+                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                        # Note: the value specified here must not be zero or be higher
+                        # than the corresponding limit.
+                  requests:
+                    type: object
+                    required:
+                      - cpu
+                      - memory
+                    properties:
+                      cpu:
+                        type: string
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                      memory:
+                        type: string
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+              schedulerName:
+                type: string
+              serviceAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              sidecars:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              spiloRunAsUser:
+                type: integer
+              spiloRunAsGroup:
+                type: integer
+              spiloFSGroup:
+                type: integer
+              standby:
+                type: object
+                properties:
+                  s3_wal_path:
+                    type: string
+                  standby_application_name:
+                    type: string
+                  standby_host:
+                    type: string
+                  standby_method:
+                    type: string
+                  standby_port:
+                    type: string
+                  standby_secret_name:
+                    type: string
+              teamId:
+                type: string
+              tls:
+                type: object
+                required:
+                  - secretName
+                properties:
+                  secretName:
+                    type: string
+                  certificateFile:
+                    type: string
+                  privateKeyFile:
+                    type: string
+                  caFile:
+                    type: string
+                  caSecretName:
+                    type: string
               tolerations:
                 type: array
                 items:
@@ -561,6 +562,26 @@ spec:
                 required:
                   - size
                 properties:
+                  iops:
+                    type: integer
+                  selector:
+                    type: object
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
                   size:
                     type: string
                     pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
@@ -569,6 +590,8 @@ spec:
                     type: string
                   subPath:
                     type: string
+                  throughput:
+                    type: integer
           status:
             type: object
             additionalProperties:

--- a/charts/postgreslet/templates/configmap.yaml
+++ b/charts/postgreslet/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
   POSTGRES_IMAGE: {{ .Values.postgreslet.postgresImage | quote  }}
   ETCD_HOST: {{ .Values.postgreslet.etcdHost | quote  }}
   ENABLE_CRD_VALIDATION: {{ .Values.postgreslet.enableCrdValidation | quote  }}
+  POSTGRES_PARAM_BLOCKLIST: {{ .Values.postgreslet.postgresParamBlockList | quote  }}
+  MAJOR_VERSION_UPGRADE_MODE: {{ .Values.postgreslet.majorVersionUpgradeMode | quote  }}
+  STANDBY_CLUSTERS_SOURCE_RANGES: {{ .Values.postgreslet.standbyClustersSourceRanges | quote  }}
 kind: ConfigMap
 metadata:
   name: {{ include "postgreslet.fullname" . }}

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -85,6 +85,12 @@ postgreslet:
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation
   enableCrdValidation: true
+  # postgresParamBlockList space-separated list of postgres params to ignore (see https://postgres-operator.readthedocs.io/en/latest/reference/cluster_manifest/#postgres-parameters)
+  postgresParamBlockList: ""
+  # majorVersionUpgradeMode defines how the operator will handle in-place version upgrades (see https://postgres-operator.readthedocs.io/en/latest/reference/operator_parameters/#major-version-upgrades)
+  majorVersionUpgradeMode: "manual"
+  # standbyClustersSourceRanges space-separated list of CIDRs
+  standbyClustersSourceRanges: ""
 
 # addRandomLabel adds a random label each time the deployment.yaml is rendered, forcing k8s to update that deployment.
 # In combination with image.PullPolicy=Always, this effetifely forces a reload of the pod, even if the image tag stays the same.

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -92,7 +92,7 @@ addRandomLabel: false
 
 sidecars:
   fluentbit:
-    image: "fluent/fluent-bit:1.7.2"
+    image: "fluent/fluent-bit:1.8.7"
     resources:
       requests:
         cpu: "100m"
@@ -119,7 +119,7 @@ sidecars:
             Match **
 
   exporter:
-    image: "prometheuscommunity/postgres-exporter:v0.9.0"
+    image: "prometheuscommunity/postgres-exporter:v0.10.0"
     containerPort: 9187
     servicePort: 9187
     resources:

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -78,9 +78,9 @@ postgreslet:
   # storageClass The name of the storageClass to use for Postgres clusters
   storageClass: "csi-lvm-sc-mirror"
   # postgresImage The operator image to use. Leave empty to use the default.
-  operatorImage: ""
+  operatorImage: "ermajn/postgres-operator:v1.7.0-1-g711648b-dirty"
   # postgresImage The Spilo image the operator should use when creating postgres instances. Leave empty to use the operator default.
-  postgresImage: ""
+  postgresImage: "cybertecpostgresql/spilo:2.1-p1_de-sync-standby-cluster_0.3.1"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation


### PR DESCRIPTION
* Update the CRD for use with the (forked) postgres-operator image
* Use the new images by default (can still be overridden)
* Add a config options required for the use with the new operator image (and two others too)