### PR TITLE
Postgreslet version pinning

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4-rc1
+version: 0.3.4

--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4-rc1

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: r.metal-stack.io/postgreslet
   pullPolicy: IfNotPresent
-  tag: "v0.2.1"
+  tag: "v0.5.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -80,7 +80,7 @@ postgreslet:
   # postgresImage The operator image to use. Leave empty to use the default.
   operatorImage: "ermajn/postgres-operator:v1.7.0-1-g711648b-dirty"
   # postgresImage The Spilo image the operator should use when creating postgres instances. Leave empty to use the operator default.
-  postgresImage: "cybertecpostgresql/spilo:2.1-p1_de-sync-standby-cluster_0.3.1"
+  postgresImage: "cybertecpostgresql/spilo:2.1-p1_de-sync-standby-cluster_0.3.2_8c82e1e"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation
@@ -98,7 +98,7 @@ addRandomLabel: false
 
 sidecars:
   fluentbit:
-    image: "fluent/fluent-bit:1.8.7"
+    image: "fluent/fluent-bit:1.8.11"
     resources:
       requests:
         cpu: "100m"
@@ -125,7 +125,7 @@ sidecars:
             Match **
 
   exporter:
-    image: "prometheuscommunity/postgres-exporter:v0.10.0"
+    image: "prometheuscommunity/postgres-exporter:v0.10.1"
     containerPort: 9187
     servicePort: 9187
     resources:


### PR DESCRIPTION
The definition of the image vector became qute cumbersome in all our installations.

To simplify things, I want to define the all versions in the postgreslet helm chart and keep that one updated.