### PR TITLE
Allow overriding of k8s-sigs images through helm

### DIFF
--- a/charts/csi-driver-lvm/templates/_helpers.tpl
+++ b/charts/csi-driver-lvm/templates/_helpers.tpl
@@ -1,29 +1,29 @@
-{{- define "externalImages.csiAttacher" -}}
+{{- define "externalImages.csiAttacher.Version" -}}
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.Version -}}
-{{- print "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0" -}}
+{{- print "v3.3.0" -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-attacher:v2.2.1" -}}
+{{- print "v2.2.1" -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "externalImages.csiProvisioner" -}}
+{{- define "externalImages.csiProvisioner.Version" -}}
 {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.Version -}}
-{{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0" -}}
+{{- print "v3.0.0" -}}
 {{- else if semverCompare ">=1.17-0" .Capabilities.KubeVersion.Version -}}
-{{- print "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2" -}}
+{{- print "v2.2.2" -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1" -}}
+{{- print "v1.6.1" -}}
 {{- end -}}
 {{- end }}
 
-{{- define "externalImages.csiLivenessprobe" -}}
-{{- print "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0" -}}
+{{- define "externalImages.csiLivenessprobe.Version" -}}
+{{- print "v2.4.0" -}}
 {{- end }}
 
-{{- define "externalImages.csiResizer" -}}
-{{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0" -}}
+{{- define "externalImages.csiResizer.Version" -}}
+{{- print "v1.3.0" -}}
 {{- end }}
 
-{{- define "externalImages.csiNodeDriverRegistrar" -}}
-{{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0" -}}
+{{- define "externalImages.csiNodeDriverRegistrar.Version" -}}
+{{- print "v2.3.0" -}}
 {{- end }}

--- a/charts/csi-driver-lvm/templates/controller.yaml
+++ b/charts/csi-driver-lvm/templates/controller.yaml
@@ -154,7 +154,7 @@ spec:
       serviceAccountName: csi-driver-lvm-controller
       containers:
         - name: csi-attacher
-          image: {{ template "externalImages.csiAttacher" . }}
+          image: {{ .Values.externalImages.attacher.repository }}:{{ template "externalImages.csiAttacher.Version" . }}
           imagePullPolicy: IfNotPresent
           args:
             - --v=5
@@ -165,7 +165,7 @@ spec:
           - mountPath: /csi
             name: socket-dir
         - name: csi-provisioner
-          image: {{ template "externalImages.csiProvisioner" . }}
+          image: {{ .Values.externalImages.provisioner.repository }}:{{ template "externalImages.csiProvisioner.Version" . }}
           imagePullPolicy: IfNotPresent
           args:
             - -v=5
@@ -177,7 +177,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: {{ template "externalImages.csiResizer" . }}
+          image: {{ .Values.externalImages.resizer.repository }}:{{ template "externalImages.csiResizer.Version" . }}
           imagePullPolicy: IfNotPresent
           args:
             - -v=5

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -149,7 +149,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: {{ template "externalImages.csiNodeDriverRegistrar" . }}
+        image: {{ .Values.externalImages.registrar.repository }}:{{ template "externalImages.csiNodeDriverRegistrar.Version" . }}
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}
@@ -226,7 +226,7 @@ spec:
         args:
         - --csi-address=/csi/csi.sock
         - --health-port=9898
-        image: {{ template "externalImages.csiLivenessprobe" . }}
+        image: {{ .Values.externalImages.livenessprobe.repository }}:{{ template "externalImages.csiLivenessprobe.Version" . }}
         imagePullPolicy: IfNotPresent
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/charts/csi-driver-lvm/values.yaml
+++ b/charts/csi-driver-lvm/values.yaml
@@ -24,3 +24,15 @@ provisionerImage:
   repository: metalstack/csi-lvmplugin-provisioner
   tag: v0.4.1
   pullPolicy: IfNotPresent
+
+externalImages:
+  attacher:
+    repository: k8s.gcr.io/sig-storage/csi-attacher
+  livenessprobe:
+    repository: k8s.gcr.io/sig-storage/livenessprobe
+  provisioner:
+    repository: k8s.gcr.io/sig-storage/csi-provisioner
+  registrar:
+    repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  resizer:
+    repository: k8s.gcr.io/sig-storage/csi-resizer


### PR DESCRIPTION
A port of https://github.com/metal-stack/csi-driver-lvm/pull/70 

Similar to other csi(s), enable overriding k8s sig images through helm. This allow using other images and not being locked to k8s sig ones.
The change set current default values in values.yaml, but allow passing an override for each during helm install.

Ideally, we should allow overriding the full image details (name and tag as well), but kept the current version lock to minimize the changes/

Tested by comparing the output of helm template before and after the change.

Signed-off-by: Roaa Sakr <romoh@microsoft.com>