### PR TITLE
The name field was used twice, therefore I got an error in kustomize.

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.5.1
+version: 0.5.2
 description: local persistend storage for lvm
 appVersion: v0.5.0
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -155,7 +155,6 @@ spec:
               fieldPath: spec.nodeName
         image: {{ template "externalImages.csiNodeDriverRegistrar" . }}
         imagePullPolicy: IfNotPresent
-        name: node-driver-registrar
         resources: {}
         securityContext:
           privileged: true


### PR DESCRIPTION
Hi, the `name` filed was used twice.
Therefore I got an error when using your chart with kustomize.
Removing the second name field of the `node-driver-registrar` container allowed me to use your chart with kustomize.
Could you please merge?