### PR TITLE
add readinessProbe to metal-api deployment

### DIFF
--- a/charts/metal-control-plane/Chart.yaml
+++ b/charts/metal-control-plane/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying the metal control plane in K8s
 name: metal-control-plane
-version: 0.3.18
+version: 0.3.19

--- a/charts/metal-control-plane/templates/metal-api.yaml
+++ b/charts/metal-control-plane/templates/metal-api.yaml
@@ -76,6 +76,13 @@ spec:
         - containerPort: 50051
           protocol: TCP
         - containerPort: 2112
+        readinessProbe:
+          httpGet:
+            path: /metal/v1/health
+            port: 8080
+          initialDelaySeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
         env:
         - name: METAL_API_BIND_ADDR
           value: 0.0.0.0


### PR DESCRIPTION
enables a more graceful rollingUpdate