### PR TITLE
Add support for Talos OS

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,7 +1,7 @@
 name: csi-driver-lvm
-version: 0.5.3
+version: 0.5.4
 description: local persistend storage for lvm
-appVersion: v0.5.1
+appVersion: v0.5.2
 apiVersion: v1
 keywords:
 - storage

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -61,10 +61,10 @@ metadata:
 spec:
   allowedHostPaths:
   - pathPrefix: /lib/modules
-  - pathPrefix: /etc/lvm/cache
+  - pathPrefix: {{ .Values.lvm.hostWritePath }}/cache
   - pathPrefix: {{ .Values.kubernetes.kubeletPath }}/plugins/{{ .Values.lvm.storageClassStub }}
-  - pathPrefix: /etc/lvm/backup
-  - pathPrefix: /run/lock/lvm
+  - pathPrefix: {{ .Values.lvm.hostWritePath }}/backup
+  - pathPrefix: {{ .Values.lvm.hostWritePath }}/lock
   - pathPrefix: {{ .Values.kubernetes.kubeletPath }}/plugins
   - pathPrefix: {{ .Values.kubernetes.kubeletPath }}/plugins_registry
   - pathPrefix: /dev
@@ -169,6 +169,7 @@ spec:
         args:
         - --drivername={{ .Values.lvm.driverName }}
         - --endpoint=unix:///csi/csi.sock
+        - --hostwritepath={{ .Values.lvm.hostWritePath }}
         - --devices={{ .Values.lvm.devicePattern }}
         - --nodeid=$(KUBE_NODE_NAME)
         - --vgname={{ .Values.lvm.vgName }}
@@ -267,15 +268,15 @@ spec:
           path: /lib/modules
         name: mod-dir
       - hostPath:
-          path: /etc/lvm/backup
+          path: {{ .Values.lvm.hostWritePath }}/backup
           type: DirectoryOrCreate
         name: lvmbackup
       - hostPath:
-          path: /etc/lvm/cache
+          path: {{ .Values.lvm.hostWritePath }}/cache
           type: DirectoryOrCreate
         name: lvmcache
       - hostPath:
-          path: /run/lock/lvm
+          path: {{ .Values.lvm.hostWritePath }}/lock
           type: DirectoryOrCreate
         name: lvmlock
 ---

--- a/charts/csi-driver-lvm/values.yaml
+++ b/charts/csi-driver-lvm/values.yaml
@@ -3,6 +3,10 @@ lvm:
   # This one you should change
   devicePattern: /dev/nvme[0-9]n[0-9]
 
+  # You will want to change this for read-only filesystems
+  # For example, in Talos OS, set this to "/var/etc/lvm"
+  hostWritePath: /etc/lvm
+
   # these are primariliy for testing purposes
   vgName: csi-lvm
   driverName: lvm.csi.metal-stack.io
@@ -17,12 +21,12 @@ compat03x: false
 
 pluginImage:
   repository: ghcr.io/metal-stack/csi-driver-lvm
-  tag: v0.5.1
+  tag: v0.5.2
   pullPolicy: IfNotPresent
 
 provisionerImage:
   repository: ghcr.io/metal-stack/csi-driver-lvm-provisioner
-  tag: v0.5.1
+  tag: v0.5.2
   pullPolicy: IfNotPresent
 
 kubernetes:


### PR DESCRIPTION
Resolves https://github.com/metal-stack/csi-driver-lvm/issues/86

`/etc` on Talos OS is read-only, which means that this chart will fail to install as is. The new `hostWritePath` option allows the default `/etc/lvm` to be overwritten. For Talos OS, setting `hostWritePath: /var/etc/lvm` fixes the install issue. This is just half the story.

After this installs, creating a PVs will fail since the controller has some hard-coded paths starting with `/etc`. Here is the second half of this fix: https://github.com/metal-stack/csi-driver-lvm/pull/87

First step is to get that PR 👆 merged first, then update the image versions in this one before merging this change.

---
Learn more about the Talos' file system: https://www.talos.dev/v1.4/learn-more/architecture/