### PR TITLE
Fix mount for node-driver-registrar

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.6.1
+version: 0.6.2
 description: local persistend storage for lvm
 appVersion: v0.5.3
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -163,6 +163,8 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
+        - mountPath: {{ .Values.kubernetes.kubeletPath }}/plugins/{{ .Values.lvm.storageClassStub }}
+          name: socket-dir
         - mountPath: /registration
           name: registration-dir
       - name: csi-driver-lvm-plugin


### PR DESCRIPTION
Currently --kubelet-registration-path parameter of node-driver-registrar container from csi-driver-lvm-plugin daemonSet points to the directory which is not mounted.
Found this out when tried to run all csi-driver-lvm containers with readOnlyRootFilesystem securityContext set to "true".