### PR TITLE
Set readOnlyRootFilesystem: true for all containers

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.6.2
+version: 0.6.3
 description: local persistend storage for lvm
 appVersion: v0.5.3
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/controller.yaml
+++ b/charts/csi-driver-lvm/templates/controller.yaml
@@ -168,6 +168,7 @@ spec:
             - --v=5
             - --csi-address=/csi/csi.sock
           securityContext:
+            readOnlyRootFilesystem: true
             privileged: true
           volumeMounts:
           - mountPath: /csi
@@ -180,6 +181,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
           securityContext:
+            readOnlyRootFilesystem: true
             privileged: true
           volumeMounts:
             - mountPath: /csi
@@ -191,6 +193,7 @@ spec:
             - -v=5
             - -csi-address=/csi/csi.sock
           securityContext:
+            readOnlyRootFilesystem: true
             privileged: true
           volumeMounts:
             - mountPath: /csi

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -157,6 +157,7 @@ spec:
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:
+          readOnlyRootFilesystem: true
           privileged: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -199,6 +200,7 @@ spec:
           protocol: TCP
         resources: {}
         securityContext:
+          readOnlyRootFilesystem: true
           privileged: true
         terminationMessagePath: /termination.log
         terminationMessagePolicy: File
@@ -232,6 +234,8 @@ spec:
         image: {{ template "externalImages.csiLivenessprobe" . }}
         imagePullPolicy: IfNotPresent
         resources: {}
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:


### PR DESCRIPTION
Hardcode readOnlyRootFilesystem set to true for all containers as a general security measure.
Host paths and volumes where rw access is needed should be mounted explicitly.

A followup of https://github.com/metal-stack/helm-charts/pull/65 and https://github.com/metal-stack/helm-charts/issues/66