### PR TITLE
Added XID exhaustion monitoring

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -532,4 +532,40 @@ sidecars:
             - local_blks_hit:
                 usage: "COUNTER"
                 description: "Total number of local block cache hits by the statement"
+      pg_xid_exhaustion:
+        query: "WITH max_age AS (
+                  SELECT
+                    2000000000 as max_old_xid,
+                    setting AS autovacuum_freeze_max_age
+                  FROM
+                    pg_catalog.pg_settings
+                  WHERE
+                    name = 'autovacuum_freeze_max_age' ),
+                    per_database_stats AS (
+                      SELECT
+                        datname,
+                        m.max_old_xid::int,
+                        m.autovacuum_freeze_max_age::int,
+                        age(d.datfrozenxid) AS oldest_current_xid
+                      FROM
+                        pg_catalog.pg_database d
+                      JOIN
+                        max_age m ON (true)
+                      WHERE d.datallowconn
+                    )
+                    SELECT max(oldest_current_xid) AS oldest_current_xid,
+                    max(ROUND(100*(oldest_current_xid/max_old_xid::float))) AS percent_towards_wraparound,
+                    max(ROUND(100*(oldest_current_xid/autovacuum_freeze_max_age::float))
+                ) AS percent_towards_emergency_autovac
+                FROM per_database_stats"
+        metrics:
+          - oldest_current_xid:
+              usage: "COUNTER"
+              description: "The ldest current xid of the whole database"
+          - percent_towards_wraparound:
+              usage: "GAUGE"
+              description: "How far in percent the database is away from being shutdown automatically upon XID exhaustion"
+          - percent_towards_emergency_autovac:
+              usage: "GAUGE"
+              description: "How far in percent if the database is away from the next emergency autovaccum has to take place"
 


### PR DESCRIPTION
For a comprehensive description of the measurements refer to:

https://www.crunchydata.com/blog/managing-transaction-id-wraparound-in-postgresql

In short: we look after the oldest XID for reference. If it reaches 2 billion, XIDs will overflow and a SELECT on an affected table will miss at least 50% of the rows. Also Postgres shuts down the database.

The percent_towards_wraparound value tells us how far away from that point we are. If it reaches 100%, then we are dead. So, at ca 95% a manual vacuum MUST be executed - AT LEAST on the affected table!

Last but not least, the percent_towards_emergency_autovac value tells us, how far away from the next emergency autovacuum we are. This happens, when autovacuum_freeze_max_age (by default 200 mio) is being reached on a table. This is just informational as this does NOT lead to immediate hazards when >100%.