### PR TITLE
feat(csi-driver-lvm): allow nodeSelector for plugin DaemonSet

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.5.4
+version: 0.5.5
 description: local persistend storage for lvm
 appVersion: v0.5.2
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -141,6 +141,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations.plugin | indent 8 }}
 {{- end }}
+{{- if .Values.nodeSelector.plugin }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector.plugin | indent 8 }}
+{{- end }}
       containers:
       - name: node-driver-registrar
         args:

--- a/charts/csi-driver-lvm/values.yaml
+++ b/charts/csi-driver-lvm/values.yaml
@@ -60,6 +60,11 @@ nodeSelector:
   # The plugin daemonset will run on all nodes if it has a toleration,
   # so it is not necessary to set a nodeSelector for it
 
+  # plugin:
+    # node-role.kubernetes.io/master: ""
+    # Key name may need to be updated to 'node-role.kubernetes.io/control-plane'
+    # in the future
+
   # The provisioner has an affinity for nodes with a plugin pod,
   # but since that's a daemonset, we allow more fine-grained node selection
 


### PR DESCRIPTION
Mirror the controller nodeSelector settings for plugins.

Useful if one wants to deploy the CSI plugins to only a subset of nodes
