### PR TITLE
Postgres: Make pg_stat_statements configurable

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/postgreslet/templates/configmap-sidecars.yaml
+++ b/charts/postgreslet/templates/configmap-sidecars.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 data:
   postgres-exporter-service-port: {{ .Values.sidecars.exporter.servicePort | quote }}
   postgres-exporter-service-target-port: {{ .Values.sidecars.exporter.containerPort | quote }}
+{{- if .Values.sidecars.exporter.enableStatementsQuery }}
+  queries.yaml: {{ printf "%s\n%s" .Values.sidecars.exporter.queries .Values.sidecars.exporter.queriesStatements | b64enc  }}
+{{- else }}
   queries.yaml: {{ b64enc .Values.sidecars.exporter.queries }}
+{{- end }}
   fluent-bit.conf: {{ b64enc .Values.sidecars.fluentbit.conf }}
   sidecars: |
     - name: postgres-exporter

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -438,3 +438,65 @@ sidecars:
           - size:
               usage: "GAUGE"
               description: "Disk space used by the database"
+      pg_stat_statements:
+        query: "SELECT
+                    pg_get_userbyid(userid) as user,
+                    pg_database.datname,
+                    pg_stat_statements.queryid,
+                    pg_stat_statements.query,
+                    pg_stat_statements.calls,
+                    pg_stat_statements.total_time as time_milliseconds,
+                    pg_stat_statements.rows,
+                    pg_stat_statements.shared_blks_hit,
+                    pg_stat_statements.shared_blks_read,
+                    pg_stat_statements.shared_blks_dirtied,
+                    pg_stat_statements.shared_blks_written,
+                    pg_stat_statements.local_blks_hit,
+                    pg_stat_statements.local_blks_read,
+                    pg_stat_statements.local_blks_dirtied,
+                    pg_stat_statements.local_blks_written,
+                    pg_stat_statements.temp_blks_read,
+                    pg_stat_statements.temp_blks_written,
+                    pg_stat_statements.blk_read_time,
+                    pg_stat_statements.blk_write_time
+                FROM pg_stat_statements
+                JOIN pg_database
+                ON pg_database.oid = pg_stat_statements.dbid"
+        metrics:
+            - user:
+                usage: "LABEL"
+                description: "The user who executed the statement"
+            - datname:
+                usage: "LABEL"
+                description: "The database in which the statement was executed"
+            - queryid:
+                usage: "LABEL"
+                description: "Internal hash code, computed from the statement's parse tree"
+            - query:
+                usage: "LABEL"
+                description: "Processed query"
+            - calls:
+                usage: "COUNTER"
+                description: "Number of times executed"
+            - time_milliseconds:
+                usage: "COUNTER"
+                description: "Total time spent in the statement, in milliseconds"
+            - rows:
+                usage: "COUNTER"
+                description: "Total number of rows retrieved or affected by the statement"
+            - shared_blks_hit:
+                usage: "COUNTER"
+                description: "Total number of shared block cache hits by the statement"
+            - shared_blks_read:
+                usage: "COUNTER"
+                description: "Total number of shared blocks read by the statement"
+            - shared_blks_dirtied:
+                usage: "COUNTER"
+                description: "Total number of shared blocks dirtied by the statement"
+            - shared_blks_written:
+                usage: "COUNTER"
+                description: "Total number of shared blocks written by the statement"
+            - local_blks_hit:
+                usage: "COUNTER"
+                description: "Total number of local block cache hits by the statement"
+

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -438,6 +438,7 @@ sidecars:
           - size:
               usage: "GAUGE"
               description: "Disk space used by the database"
+    queriesStatements: |+
       pg_stat_statements:
         query: "SELECT
                     pg_get_userbyid(userid) as user,
@@ -499,4 +500,5 @@ sidecars:
             - local_blks_hit:
                 usage: "COUNTER"
                 description: "Total number of local block cache hits by the statement"
+    enableStatementsQuery: false
 


### PR DESCRIPTION
After disabling it for performance reasons, it was now decided to make it configurable for certain partitions.

To prevent duplicate definitions of exporter queries, this is handled directly in the chart (and not by overriding the value during the deployment of the chart for example)