### PR TITLE
Update csi driver sidecars

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.6.0
+version: 0.6.1
 description: local persistend storage for lvm
 appVersion: v0.5.2
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/_helpers.tpl
+++ b/charts/csi-driver-lvm/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{- if .Values.customCSISidecars.enabled -}}
 {{- print .Values.customCSISidecars.attacher -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0" -}}
+{{- print "registry.k8s.io/sig-storage/csi-attacher:v4.5.0" -}}
 {{- end -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@
 {{- if .Values.customCSISidecars.enabled -}}
 {{- print .Values.customCSISidecars.provisioner -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0" -}}
+{{- print "registry.k8s.io/sig-storage/csi-provisioner:v4.0.0" -}}
 {{- end -}}
 {{- end -}}
 
@@ -18,7 +18,7 @@
 {{- if .Values.customCSISidecars.enabled -}}
 {{- print .Values.customCSISidecars.livenessprobe -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0" -}}
+{{- print "registry.k8s.io/sig-storage/livenessprobe:v2.12.0" -}}
 {{- end -}}
 {{- end -}}
 
@@ -26,7 +26,7 @@
 {{- if .Values.customCSISidecars.enabled -}}
 {{- print .Values.customCSISidecars.resizer -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0" -}}
+{{- print "registry.k8s.io/sig-storage/csi-resizer:v1.10.0" -}}
 {{- end -}}
 {{- end -}}
 
@@ -34,6 +34,6 @@
 {{- if .Values.customCSISidecars.enabled -}}
 {{- print .Values.customCSISidecars.registrar -}}
 {{- else -}}
-{{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0" -}}
+{{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/metal-control-plane/Chart.yaml
+++ b/charts/metal-control-plane/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying the metal control plane in K8s
 name: metal-control-plane
-version: 0.4.1
+version: 0.4.2


### PR DESCRIPTION
k8s.gcr.io is deprecated, also update the versions.

Required for: https://github.com/metal-stack/csi-driver-lvm/pull/100