### PR TITLE
add queryid to avoid duplicate rows error which leads to exporter crash

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -437,6 +437,7 @@ sidecars:
         query: "SELECT
                     pg_get_userbyid(userid) as user,
                     pg_database.datname,
+                    pg_stat_statements.queryid,
                     pg_stat_statements.query,
                     pg_stat_statements.calls,
                     pg_stat_statements.total_exec_time as time_milliseconds,
@@ -452,6 +453,9 @@ sidecars:
             - datname:
                 usage: "LABEL"
                 description: "The database in which the statement was executed"
+            - queryid:
+                usage: "LABEL"
+                description: "Query ID"
             - query:
                 usage: "LABEL"
                 description: "Processed query"


### PR DESCRIPTION
This PR replaces https://github.com/metal-stack/helm-charts/pull/87 by using a new branch directly instead of a fork. It also bumps the postgreslet chart version to `0.13.1`.