### PR TITLE
Add missing mount of lvm archive directory.

### DIFF
--- a/charts/csi-driver-lvm/Chart.yaml
+++ b/charts/csi-driver-lvm/Chart.yaml
@@ -1,5 +1,5 @@
 name: csi-driver-lvm
-version: 0.6.3
+version: 0.6.4
 description: local persistend storage for lvm
 appVersion: v0.5.3
 apiVersion: v1

--- a/charts/csi-driver-lvm/templates/plugin.yaml
+++ b/charts/csi-driver-lvm/templates/plugin.yaml
@@ -231,6 +231,9 @@ spec:
         - mountPath: /etc/lvm/cache
           name: lvmcache
           mountPropagation: Bidirectional
+        - mountPath: /etc/lvm/archive
+          name: lvmarchive
+          mountPropagation: Bidirectional
         - mountPath: /run/lock/lvm
           name: lvmlock
           mountPropagation: Bidirectional
@@ -285,6 +288,10 @@ spec:
           path: {{ .Values.lvm.hostWritePath }}/cache
           type: DirectoryOrCreate
         name: lvmcache
+      - hostPath:
+          path: {{ .Values.lvm.hostWritePath }}/archive
+          type: DirectoryOrCreate
+        name: lvmarchive
       - hostPath:
           path: {{ .Values.lvm.hostWritePath }}/lock
           type: DirectoryOrCreate


### PR DESCRIPTION
Regression of https://github.com/metal-stack/helm-charts/pull/67.

```
E0924 11:25:04.026502       1 server.go:114] GRPC error: unable to create lv: exit status 5 output:  Creating logical volume csi-d3f9243895aa3b4fa14390986b1996671cdd5d6cf8409ba558d570714d6e18e1
  Cannot archive volume group metadata for csi-lvm to read-only filesystem.
```