### PR TITLE
Default PDB minAvailable to one and make it configurable

### DIFF
--- a/charts/metal-control-plane/Chart.yaml
+++ b/charts/metal-control-plane/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying the metal control plane in K8s
 name: metal-control-plane
-version: 0.4.5
+version: 0.4.6

--- a/charts/metal-control-plane/templates/ipam.yaml
+++ b/charts/metal-control-plane/templates/ipam.yaml
@@ -90,7 +90,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ipam-pdb
 spec:
-  minAvailable: 2
+  minAvailable: {{ .Values.pod_disruption_budget.min_available }}
   selector:
     matchLabels:
       app: ipam

--- a/charts/metal-control-plane/values.yaml
+++ b/charts/metal-control-plane/values.yaml
@@ -136,6 +136,9 @@ ipam:
   db_user: ""
   db_password: ""
 
+pod_disruption_budget:
+  min_available: 1
+
 masterdata_api:
   provider_tenant: ""
   db_address: ""


### PR DESCRIPTION
## Description

By default the ipam deployment has two `Replicas` and the `PodDisruptionBudget` `minAvailable` property is set to two. This prevents disruptions, when performing Kubernetes operation updates.
This PR defaults `minAvailable` property to one and makes it configurable.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
