### PR TITLE
add pg_sync_standby_nominal_actual and pg_replication_blocked_transactions

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -433,6 +433,55 @@ sidecars:
           - size:
               usage: "GAUGE"
               description: "Disk space used by the database"
+
+      pg_sync_standby_nominal_actual:
+        query: "WITH config AS (
+                    SELECT
+                        COALESCE(ARRAY_LENGTH(STRING_TO_ARRAY(setting, ','), 1), 0)
+                        AS nominal_sync_standbys
+                    FROM
+                        pg_settings
+                    WHERE
+                        name = 'synchronous_standby_names'
+                ),
+                current AS (
+                    SELECT
+                        COUNT(*) AS actual_sync_standbys
+                    FROM
+                        pg_stat_replication
+                    WHERE
+                        sync_state = 'sync'
+                )
+                SELECT
+                    config.nominal_sync_standbys,
+                    current.actual_sync_standbys,
+                    CASE
+                        WHEN current.actual_sync_standbys >= config.nominal_sync_standbys THEN 1
+                        ELSE 0
+                    END AS status
+                FROM
+                    config, current"
+        metrics:
+          - nominal_sync_standbys:
+              usage: "GAUGE"
+              description: "The number of nominal (configured) sync standbys"
+          - actual_sync_standbys:
+              usage: "GAUGE"
+              description: "The number of actual subscribed standbys"
+          - status:
+              usage: "GAUGE"
+              description: "Result of nominal-actual-comparision: 1=OK, 0=Fail (sync standbys are missing)"
+
+      pg_replication_blocked_transactions:
+        query: "SELECT COUNT(*) AS blocked_transactions
+          FROM pg_stat_activity
+          WHERE state = 'active'
+          AND wait_event='SyncRep'"
+        metrics:
+          - blocked_transactions:
+              usage: "COUNTER"
+              description: "Number of blocked transactions waiting for a defect sync standby"
+              
     queriesStatements: |+
       pg_stat_statements:
         # user, datname, query, calls, total_exec_time, rows.


### PR DESCRIPTION
## Description

Add two more monitoring metrics to postgreslet deployment queries.yaml:

- `pg_sync_standby_nominal_actual`: show if nominal and actual sync standbys, if any, are matching, becomes critical when nominal!=actual
- `pg_replication_blocked_transactions`: show the number of transactions blocked by one or more defect sync standbys

These two additional metrics fix the following problem: every once in a while a sync standby in another DC fails (for whatever reason). Now if someone issues a write transaction on the primary (e.g. insert, update or delete), then this query will hang (forever or until some timeout). On a high load instance the apps using the database will after some time get stuck and in the end the whole system stands still.

However, currently we do not have any means to monitor such events. From our current monitoring view, everything on the primary looks fantastic. So with these two new metrics we are now able to issue a critical alert when a sync standby is unresponsive and thereby blocking transactions on the primary.