### PR TITLE
rollback image

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -91,7 +91,7 @@ postgreslet:
   # postgresImageRepository 
   postgresImageRepository: "docker.io/cybertecpostgresql/spilo"
   # postgresImageTag 
-  postgresImageTag: "3.3-p2_de-sync-standby-cluster_0.4_2024-11-27"
+  postgresImageTag: "3.2-p3_de-sync-standby-cluster_0.4_2024-07-02"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation


### PR DESCRIPTION
The image in the current values file creates an error when starting up a PG 15 database:

~~~
pgfits-testcreatepostg1c8a8-0 postgres 2025-01-27 08:32:20.618 UTC [249]: [1-1] db=,user=,app=,client= FATAL:  XX000: incompatible library "/usr/lib/postgresql/15/lib/bg_mon.so": version mismatch
pgfits-testcreatepostg1c8a8-0 postgres 2025-01-27 08:32:20.618 UTC [249]: [2-1] db=,user=,app=,client= DETAIL:  Server is version 15, library is version 14.
~~~

so we use the old image where this error does not exist