### PR TITLE
use distinct on pg_stat_statements to avoid postgres-exporter crash

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -485,7 +485,7 @@ sidecars:
     queriesStatements: |+
       pg_stat_statements:
         # user, datname, query, calls, total_exec_time, rows.
-        query: "SELECT
+        query: "SELECT distinct
                     pg_get_userbyid(userid) as user,
                     pg_database.datname,
                     pg_stat_statements.queryid,


### PR DESCRIPTION
## Description

In this PR we add a `distinct` to the `pg_stat_statements` query (postgres exporter custom metrics), which is required to avoid postgres-exporter crashes. These crashes happen when duplicate results are being returned in some rare cases.

This extents PR https://github.com/metal-stack/helm-charts/pull/94 which was incomplete for that matter.