### PR TITLE
Postgreslet update spilo image

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.16.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.16.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.17.1"
+appVersion: "v0.18.0"

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -91,7 +91,7 @@ postgreslet:
   # postgresImageRepository
   postgresImageRepository: "docker.io/cybertecpostgresql/spilo"
   # postgresImageTag
-  postgresImageTag: "3.3-p2_de-sync-standby-cluster_0.4_2025-01-29"
+  postgresImageTag: "3.2-p3_de-sync-standby-cluster_0.4_2025-02-11"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -91,7 +91,7 @@ postgreslet:
   # postgresImageRepository
   postgresImageRepository: "docker.io/cybertecpostgresql/spilo"
   # postgresImageTag
-  postgresImageTag: "3.2-p3_de-sync-standby-cluster_0.4_2025-02-11"
+  postgresImageTag: "3.2_2025-03-03"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation


### PR DESCRIPTION
## Description

Going back to using the 3.2 spilo image, but with updated postgresql packages. This is neccessary because the updated wal-g in the newer spilo image changed the output of the cli, which breaks the cleanup of old backups.

Also fix the `appVersion` of the chart to match the actual postgreslet version.

This does not (yet) contain the updated spilo images for `CVE-2025-1094`.
