### PR TITLE
increase default memory limit for wal-g-exporter

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.3
+version: 0.16.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -552,4 +552,4 @@ sidecars:
         memory: "100M"
       limits:
         cpu: "500m"
-        memory: "256M"
+        memory: "500M"


### PR DESCRIPTION
## Description

The new wal-g-exporter needs more memory as 256M sometimes, which leads to OOM kills. This PR increases the default memory limit to 500M to circumvent this.


