### PR TITLE
Fix SQL error in postgres-exporter query config when executing WAL check on standby node

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -293,7 +293,11 @@ sidecars:
               description: "Replication lag in bytes"
 
       pg_replication_slots:
-        query: "SELECT slot_name, active::int, pg_wal_lsn_diff(pg_current_wal_insert_lsn(), restart_lsn) AS retained_bytes FROM pg_catalog.pg_replication_slots"
+        query: "SELECT
+          slot_name, active::int,
+          pg_wal_lsn_diff(pg_current_wal_insert_lsn(), restart_lsn) AS retained_bytes
+          FROM pg_catalog.pg_replication_slots
+          LIMIT (CASE WHEN pg_is_in_recovery() THEN 0 END)"
         metrics:
           - slot_name:
               usage: "LABEL"


### PR DESCRIPTION
## Description

This statement fails on standby nodes:

```default
postgres=# SELECT slot_name, active::int, pg_wal_lsn_diff(pg_current_wal_insert_lsn(), restart_lsn) AS retained_bytes FROM pg_catalog.pg_replication_slots;                         
ERROR:  recovery is in progress
HINT:  WAL control functions cannot be executed during recovery.
```

This causes lots of alerts if one monitors the `pg_exporter_last_scrape_error` Metric. This proposal adds a condition so that the statement is only being executed if the node is a writable primary node.