### PR TITLE
Add valkey chart to remove dependency from bitnami

### DIFF
--- a/charts/valkey/.helmignore
+++ b/charts/valkey/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: valkey
+description: An opinionated valkey cluster setup for metal-stack
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "8.1.3"

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Installing Valkey HelmChart for Metalstack named {{ .Release.Name }}.
+
+{{- if .Values.cluster.enabled }}
+Cluster-mode is enabled with {{ .Values.replicaCount }} total instances.
+
+The current setup has a glitch, that it is required to run `redis-cli --cluster fix <host>:<port>` before the cluster is usable.
+Contributions to fix that are highly appreciated.
+{{- else }}
+Cluster mode is disabled using 1 instance.
+{{- end }}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -60,3 +60,13 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine number of replicas
+*/}}
+{{- define "valkey.replicas" -}}
+{{- if .Values.cluster.enabled }}
+{{- .Values.replicaCount }}
+{{- else }}1
+{{- end }}
+{{- end }}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "valkey.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "valkey.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "valkey.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "valkey.labels" -}}
+helm.sh/chart: {{ include "valkey.chart" . }}
+{{ include "valkey.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "valkey.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "valkey.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "valkey.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "valkey.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valkey
+data:
+  valkey.conf: |
+    protected-mode no
+    notify-keyspace-events "KEA$"
+    cluster-enabled yes
+    cluster-config-file nodes.conf
+    cluster-node-timeout 5000
+    cluster-allow-reads-when-down yes
+    cluster-announce-port 6379
+    cluster-announce-bus-port 16379
+    port 6379
+    cluster-port 16379
+    appendonly yes
+    replica-read-only no
+  init-config.sh: |
+    #!/bin/sh
+
+    cp /etc/valkey/valkey.conf /tmp/valkey.conf
+    if [ "${REPLICAS}" -gt "1" ]; then
+      echo "replica-announce-ip ${POD_IP}" >> /tmp/valkey.conf
+      echo "cluster-announce-ip ${POD_IP}" >> /tmp/valkey.conf
+    fi
+    cp /tmp/valkey.conf /config/valkey.conf
+
+    mkdir -p /data
+    chown -R 1000:1000 /data
+
+  init-cluster.sh: |
+    #!/bin/sh
+
+    if [ "${REPLICAS}" -eq "1" ]; then
+      echo "Single node deployment. Skipping cluster initialization"
+      exit 0
+    fi
+
+    ORDINAL=$(echo ${HOSTNAME} | rev | cut -d'-' -f1 | rev)
+    PRIMARIES=$(((${REPLICAS} + 1) / 2))
+
+    echo "Initializing as ordinal $ORDINAL and $PRIMARIES primaries"
+    if [ "${ORDINAL}" = "0" ]; then
+      echo "This is the primary-0 node"
+
+      until valkey-cli -h localhost -p 6379 ping 2>/dev/null; do
+        echo "Waiting for local Valkey to start..."
+        sleep 2
+      done
+      echo "Local Valkey is ready"
+
+      if ! valkey-cli -h localhost -p 6379 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
+        echo "Initializing cluster..."
+
+      NODES=""
+      for i in $(seq 0 $((${REPLICAS}-1))); do
+        if [ "$i" = "0" ]; then
+          NODES="${NODES} ${POD_IP}:6379"
+        else
+          NODES="${NODES} valkey-${i}.${HOSTNAME}.${NAMESPACE}.svc.cluster.local:6379"
+        fi
+      done
+
+        REPLICA_COUNT=$(((${REPLICAS} - ${PRIMARIES}) / ${PRIMARIES}))
+
+        echo "Creating cluster with ${PRIMARIES} primaries and ${REPLICA_COUNT} replicas per primary"
+        echo "Creating cluster with nodes: ${NODES}"
+        echo "yes" | valkey-cli --cluster create ${NODES} --cluster-replicas ${REPLICA_COUNT}
+      else
+        echo "Cluster already initialized"
+      fi
+    elif [ "${ORDINAL}" -ge "${PRIMARIES}" ]; then
+      PRIMARY_INDEX=$((${ORDINAL} % ${PRIMARIES}))
+      PRIMARY_HOST="valkey-${PRIMARY_INDEX}.${HOSTNAME}.${NAMESPACE}.svc.cluster.local"
+
+      echo "This is a replica node. Will join cluster via ${PRIMARY_HOST}"
+      until valkey-cli -h ${PRIMARY_HOST} -p 6379 ping 2>/dev/null; do
+        echo "Waiting for primary ${PRIMARY_HOST} to be ready..."
+        sleep 5
+      done
+
+      echo "Primary is ready, joining cluster..."
+      valkey-cli --cluster add-node ${POD_IP}:6379 ${PRIMARY_HOST}:6379 --cluster-replica
+    else
+      echo "This is a primary node. Will join cluster via valkey-0.${NAMESPACE}.svc.cluster.local"
+      until valkey-cli -h valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local -p 6379 ping 2>/dev/null; do
+        echo "Waiting for valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local to be ready..."
+        sleep 5
+      done
+
+      echo "Cluster primary is ready, joining cluster..."
+      valkey-cli --cluster add-node ${POD_IP}:6379 valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local:6379
+    fi

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -58,7 +58,7 @@ data:
         if [ "$i" = "0" ]; then
           NODES="${NODES} ${POD_IP}:6379"
         else
-          NODES="${NODES} valkey-${i}.${HOSTNAME}.${NAMESPACE}.svc.cluster.local:6379"
+          NODES="${NODES} valkey-${i}.valkey.${NAMESPACE}.svc.cluster.local:6379"
         fi
       done
 
@@ -72,7 +72,7 @@ data:
       fi
     elif [ "${ORDINAL}" -ge "${PRIMARIES}" ]; then
       PRIMARY_INDEX=$((${ORDINAL} % ${PRIMARIES}))
-      PRIMARY_HOST="valkey-${PRIMARY_INDEX}.${HOSTNAME}.${NAMESPACE}.svc.cluster.local"
+      PRIMARY_HOST="valkey-${PRIMARY_INDEX}.valkey.${NAMESPACE}.svc.cluster.local"
 
       echo "This is a replica node. Will join cluster via ${PRIMARY_HOST}"
       until valkey-cli -h ${PRIMARY_HOST} -p 6379 ping 2>/dev/null; do
@@ -84,11 +84,11 @@ data:
       valkey-cli --cluster add-node ${POD_IP}:6379 ${PRIMARY_HOST}:6379 --cluster-replica
     else
       echo "This is a primary node. Will join cluster via valkey-0.${NAMESPACE}.svc.cluster.local"
-      until valkey-cli -h valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local -p 6379 ping 2>/dev/null; do
-        echo "Waiting for valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local to be ready..."
+      until valkey-cli -h valkey-0.valkey.${NAMESPACE}.svc.cluster.local -p 6379 ping 2>/dev/null; do
+        echo "Waiting for valkey-0.valkey.${NAMESPACE}.svc.cluster.local to be ready..."
         sleep 5
       done
 
       echo "Cluster primary is ready, joining cluster..."
-      valkey-cli --cluster add-node ${POD_IP}:6379 valkey-0.${HOSTNAME}.${NAMESPACE}.svc.cluster.local:6379
+      valkey-cli --cluster add-node ${POD_IP}:6379 valkey-0.valkey.${NAMESPACE}.svc.cluster.local:6379
     fi

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -6,24 +6,29 @@ data:
   valkey.conf: |
     protected-mode no
     notify-keyspace-events "KEA$"
+    port 6379
+    appendonly yes
+{{ if .Values.cluster.enabled }}
+    replica-read-only no
     cluster-enabled yes
     cluster-config-file nodes.conf
     cluster-node-timeout 5000
     cluster-allow-reads-when-down yes
     cluster-announce-port 6379
     cluster-announce-bus-port 16379
-    port 6379
     cluster-port 16379
-    appendonly yes
-    replica-read-only no
+{{ end }}
+
   init-config.sh: |
     #!/bin/sh
 
     cp /etc/valkey/valkey.conf /tmp/valkey.conf
-    if [ "${REPLICAS}" -gt "1" ]; then
-      echo "replica-announce-ip ${POD_IP}" >> /tmp/valkey.conf
-      echo "cluster-announce-ip ${POD_IP}" >> /tmp/valkey.conf
-    fi
+    
+{{ if .Values.cluster.enabled }}
+    echo "replica-announce-ip ${POD_IP}" >> /tmp/valkey.conf
+    echo "cluster-announce-ip ${POD_IP}" >> /tmp/valkey.conf
+{{ end }}
+
     cp /tmp/valkey.conf /config/valkey.conf
 
     mkdir -p /data

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: client
+      port: {{ .Values.ports.client.port }}
+      targetPort: {{ .Values.ports.client.port }}
+    - name: cluster
+      port: {{ .Values.ports.cluster.port }}
+      targetPort: {{ .Values.ports.cluster.port }}
+    {{- if .Values.prometheusExporter.enable }}
+    - name: metrics
+      port: {{ .Values.prometheusExporter.port }}
+      targetPort: {{ .Values.prometheusExporter.port }}
+    {{- end}}
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -1,7 +1,32 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: client
+      port: {{ .Values.ports.client.port }}
+      targetPort: {{ .Values.ports.client.port }}
+    - name: cluster
+      port: {{ .Values.ports.cluster.port }}
+      targetPort: {{ .Values.ports.cluster.port }}
+    {{- if .Values.prometheusExporter.enable }}
+    - name: metrics
+      port: {{ .Values.prometheusExporter.port }}
+      targetPort: {{ .Values.prometheusExporter.port }}
+    {{- end}}
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-primary
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 spec:

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -18,31 +18,9 @@ spec:
       port: {{ .Values.prometheusExporter.port }}
       targetPort: {{ .Values.prometheusExporter.port }}
     {{- end}}
-  type: ClusterIP
+  type: {{ .Values.service.type }}
+  {{- if .Values.cluster.enabled }}
   clusterIP: None
-  selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "valkey.fullname" . }}-primary
-  labels:
-    {{- include "valkey.labels" . | nindent 4 }}
-spec:
-  ports:
-    - name: client
-      port: {{ .Values.ports.client.port }}
-      targetPort: {{ .Values.ports.client.port }}
-    - name: cluster
-      port: {{ .Values.ports.cluster.port }}
-      targetPort: {{ .Values.ports.cluster.port }}
-    {{- if .Values.prometheusExporter.enable }}
-    - name: metrics
-      port: {{ .Values.prometheusExporter.port }}
-      targetPort: {{ .Values.prometheusExporter.port }}
-    {{- end}}
-  type: ClusterIP
-  clusterIP: None
+  {{- end}}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}

--- a/charts/valkey/templates/serviceaccount.yaml
+++ b/charts/valkey/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "valkey.serviceAccountName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "valkey.replicas" . }}
   podManagementPolicy: Parallel
   serviceName: {{ include "valkey.fullname" . }}
   selector:
@@ -44,7 +44,7 @@ spec:
               mountPath: /data
           env:
             - name: REPLICAS
-              value: {{ .Values.replicaCount | quote }}
+              value: {{ include "valkey.replicas" . | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -69,7 +69,7 @@ spec:
               fieldRef:
                 fieldPath: "metadata.name"
           - name: REPLICAS
-            value: {{ .Values.replicaCount | quote }}
+            value: {{ include "valkey.replicas" . | quote }}
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -158,6 +158,9 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        {{- with .Values.storage.data.storageClass }}
+        storageClass:  {{ .Values.storage.data.storageClass }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.storage.data.claimSize }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
               mountPath: /scripts
             - name: workdir
               mountPath: /config
-            - name: data
+            - name: {{ .Values.storage.data.claimName }}
               mountPath: /data
           env:
             - name: REPLICAS
@@ -91,7 +91,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
+            - name: {{ .Values.storage.data.claimName }}
               mountPath: /data
             - name: workdir
               mountPath: /etc/valkey
@@ -155,7 +155,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: data
+        name: {{ .Values.storage.data.claimName }}
       spec:
         accessModes: ["ReadWriteOnce"]
         {{- with .Values.storage.data.storageClass }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: Parallel
+  serviceName: {{ include "valkey.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "valkey.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # setup configuration, directories and ensure correct permissions
+      initContainers:
+        - name: init-config
+          image: busybox
+          command: ["sh", "/scripts/init-config.sh"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey
+              readOnly: true
+            - name: scripts
+              mountPath: /scripts
+            - name: workdir
+              mountPath: /config
+            - name: data
+              mountPath: /data
+          env:
+            - name: REPLICAS
+              value: {{ .Values.replicaCount | quote }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP        
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c"]
+          args: ["sh /scripts/init-cluster.sh & valkey-server /etc/valkey/valkey.conf"]
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: "metadata.name"
+          - name: REPLICAS
+            value: {{ .Values.replicaCount | quote }}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace    
+          ports:
+            - name: client
+              containerPort: 6379
+            - name: cluster
+              containerPort: 16379
+          readinessProbe:
+            exec:
+              command:
+              - redis-cli
+              - ping
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: workdir
+              mountPath: /etc/valkey
+            - name: scripts
+              mountPath: /scripts
+            {{- with .Values.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: redis-exporter
+          image: oliver006/redis_exporter:latest
+          securityContext:
+            runAsUser: 59000
+            runAsGroup: 59000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: {{ .Values.prometheusExporter.port }}
+              name: metrics
+          env:
+            - name: REDIS_ADDR
+              value: redis://localhost:6379
+            - name: REDIS_EXPORTER_IS_CLUSTER
+              value: "true"
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: valkey
+        - name: scripts
+          configMap:
+            name: valkey
+            items:
+              - key: init-cluster.sh
+                path: init-cluster.sh
+              - key: init-config.sh
+                path: init-config.sh
+            defaultMode: 0755
+        - name: workdir
+          emptyDir: {}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.storage.data.claimSize }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -76,9 +76,9 @@ spec:
                 fieldPath: metadata.namespace    
           ports:
             - name: client
-              containerPort: 6379
+              containerPort: {{ .Values.ports.client.port }}
             - name: cluster
-              containerPort: 16379
+              containerPort: {{ .Values.ports.cluster.port }}
           readinessProbe:
             exec:
               command:
@@ -119,7 +119,7 @@ spec:
               name: metrics
           env:
             - name: REDIS_ADDR
-              value: redis://localhost:6379
+              value: redis://localhost:{{ .Values.ports.client.port }}
             - name: REDIS_EXPORTER_IS_CLUSTER
               value: "true"
         {{- end }}

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -4,10 +4,10 @@
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 cluster:
-  enabled: true
+  enabled: false ## cluster mode not fully supported yet
 
 # Number of total instances, reset to 1 if cluster disabled
-replicaCount: 6
+replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -1,0 +1,89 @@
+# Default values for valkey.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 6
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: valkey/valkey
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+ports:
+  client:
+    port: 6379
+  cluster:
+    port: 16379
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+
+prometheusExporter:
+  enabled: true
+  port: 9121
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+storage:
+  data:
+    claimSize: 5Gi
+
+# Additional volumes on the output Deployment definition.
+volumes: {}
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -82,6 +82,8 @@ resources: {}
 storage:
   data:
     claimSize: 5Gi
+    claimName: valkey-data
+    storageClass:
 
 # Additional volumes on the output Deployment definition.
 volumes: {}

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -3,6 +3,10 @@
 # Declare variables to be passed into your templates.
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+cluster:
+  enabled: true
+
+# Number of total instances, reset to 1 if cluster disabled
 replicaCount: 6
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -48,6 +48,9 @@ ports:
   cluster:
     port: 16379
 
+service:
+  type: ClusterIP
+
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000


### PR DESCRIPTION
## Description
Created Helm Chart for Valkey, because the modification of the original Bitnami-Chart is too complex in comparison.

Used tutorial https://blog.enapi.com/valkey-clusters-in-kubernetes-a-comprehensive-guide-94994d0a8ebb for help.

The current version is mainly for testing purposes. Therefore, it has a switch, whether to use it in cluster-mode with the specified amount of instances or in single mode with one instance.

In cluster-mode, there is still an issue, that requires to run redis-cli --cluster fix <host>:<port> to reassign the slots before the cluster is usable. Need help to fix this.

Therefore, only the single-mode is supported yet, but should be fine for testing purposes.

References https://github.com/metal-stack/releases/issues/249.