### PR TITLE
fix spacing so that CM renders nicely when printing it

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -485,7 +485,7 @@ sidecars:
           - status:
               usage: "GAUGE"
               description: "Result of nominal-actual-comparision: 1=OK, 0=Fail (sync standbys are missing)"
-    
+
       pg_roles:
         query: |
             SELECT
@@ -506,7 +506,7 @@ sidecars:
                 ON rl.rolname = st.usename
             WHERE
                 rl.rolcanlogin = true
-            AND    
+            AND
                 rl.rolname NOT IN ('standby','monitoring','postgres')
             AND
                 rl.rolname NOT LIKE '%prepdb01_%user'
@@ -519,7 +519,7 @@ sidecars:
                 rl.rolreplication,
                 rl.rolbypassrls,
                 rl.oid
-            LIMIT (CASE WHEN pg_is_in_recovery() THEN 0 END);    
+            LIMIT (CASE WHEN pg_is_in_recovery() THEN 0 END);
         metrics:
           - rolname:
               usage: "LABEL"


### PR DESCRIPTION
## Description

Commit df4682a introduced excess whitespaces in a yaml file, one case on an empty line and two times we had spaces before `\n`. This leads to garbled output, when printing the CM on the console using `kubectl get -o yaml`, i.e.:

<img width="905" height="231" alt="garbledqueries" src="https://github.com/user-attachments/assets/73be32fc-8506-45ef-a8f7-7f5575c830b7" />

References:
- https://github.com/kubernetes/kubernetes/issues/36222