### PR TITLE
Postgreslet: Add config options for the podTopologySpreadConstraints webhook

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.21.0"
+appVersion: "v0.22.0"

--- a/charts/postgreslet/templates/configmap.yaml
+++ b/charts/postgreslet/templates/configmap.yaml
@@ -63,6 +63,10 @@ data:
   WALG_EXPORTER_MEMORY_LIMIT: "{{ .Values.sidecars.walGExporter.resources.limits.memory }}"
   POD_ANTIAFFINITY_PREFERRED_DURING_SCHEDULING: {{ .Values.postgreslet.podAntiaffinityPreferredDuringScheduling | quote }}
   POD_ANTIAFFINITY_TOPOLOGY_KEY: {{ .Values.postgreslet.podAntiaffinityTopologyKey | quote }}
+  ENABLE_POD_TOPOLOGY_SPREAD_CONSTRAINT_WEBHOOK: {{ .Values.postgreslet.enablePodTopologySpreadConstraintWebhook | quote  }}
+  POD_TOPOLOGY_SPREAD_CONSTRAINT_TOPOLOGY_KEY: {{ .Values.postgreslet.podTopologySpreadConstraintTopologyKey | quote }}
+  POD_TOPOLOGY_SPREAD_CONSTRAINT_MAX_SKEW: {{ .Values.postgreslet.podTopologySpreadConstraintMaxSkew | quote }}
+  POD_TOPOLOGY_SPREAD_CONSTRAINT_MIN_DOMAINS: {{ .Values.postgreslet.podTopologySpreadConstraintMinDomains | quote }}
 kind: ConfigMap
 metadata:
   name: {{ include "postgreslet.fullname" . }}

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -91,7 +91,7 @@ postgreslet:
   # postgresImageRepository
   postgresImageRepository: "containers.cybertec.at/f-i-ts/spilo-16"
   # postgresImageTag
-  postgresImageTag: "4.0_2025-07-21"
+  postgresImageTag: "4.0_2025-09-01"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: r.metal-stack.io/postgreslet
   pullPolicy: IfNotPresent
-  tag: "v0.21.0"
+  tag: "v0.22.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -150,6 +150,14 @@ postgreslet:
   podAntiaffinityPreferredDuringScheduling: false
   # podAntiaffinityTopologyKey when anti affinity is enabled, overrides the topology key for anti affinity
   podAntiaffinityTopologyKey: ""
+  # enablePodTopologySpreadConstraintWebhook when enabled, overwrites the podTopologyContstraints with our custom one
+  enablePodTopologySpreadConstraintWebhook: false
+  # podTopologySpreadConstraintTopologyKey changes the topologyKey to use in our custom podTopologyConstraint
+  podTopologySpreadConstraintTopologyKey: "machine.metal-stack.io/rack"
+  # ppodTopologySpreadConstraintMaxSkew changes the maxSkew to use in our custom podTopologyConstraint
+  podTopologySpreadConstraintMaxSkew: 1
+  # podTopologySpreadConstraintMinDomains changes the minDomains to use in our custom podTopologyConstraint. When set to a value larger than 0, whenUnsatisfiable changes from ScheduleAnyway to DoNotSchedule, effectively switching from a soft to a hard scheduling requirement.
+  podTopologySpreadConstraintMinDomains: 0
 
 # addRandomLabel adds a random label each time the deployment.yaml is rendered, forcing k8s to update that deployment.
 # In combination with image.PullPolicy=Always, this effetifely forces a reload of the pod, even if the image tag stays the same.


### PR DESCRIPTION
## Description

This PR adds the configuration options for the newly introduced podTopologySpreadConstraint webhook to the postgreslet helm chart.