### PR TITLE
add plsql function to get a list of pg extensions per logical db

### DIFF
--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -569,19 +569,6 @@ sidecars:
               usage: "COUNTER"
               description: "Number of wal receiving connections to the primary database. 2=Primary (not receiving), 1=OK (connected), 0=Fail (no connection to primary)"
 
-      pg_database_extensions:
-        query: "SELECT * FROM collect_all_extensions();"
-        metrics:
-          - database_name:
-              usage: "LABEL"
-              description: "logical database"
-          - extension_name:
-              usage: "LABEL"
-              description: "enabled extension"
-          - count:
-              usage: "GAUGE"
-              description: "extension count"
-
     queriesStatements: |+
       pg_stat_statements:
         # user, datname, query, calls, total_exec_time, rows.


### PR DESCRIPTION
## Description

Time and time again we need to check if we are affected by certain vulnerabilities of some postgres extension. To check which extensions are enabled on all logical databases on all postgres instances is tedious manual work.

This PR adds a PLsql function which we use in our default postgres_exporter metrics to have this list easily available all the time.
