### PR TITLE
Postgreslet next release

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.23.0"
+appVersion: "v0.25.0"

--- a/charts/postgreslet/templates/configmap.yaml
+++ b/charts/postgreslet/templates/configmap.yaml
@@ -68,6 +68,7 @@ data:
   POD_TOPOLOGY_SPREAD_CONSTRAINT_MAX_SKEW: {{ .Values.postgreslet.podTopologySpreadConstraintMaxSkew | quote }}
   POD_TOPOLOGY_SPREAD_CONSTRAINT_MIN_DOMAINS: {{ .Values.postgreslet.podTopologySpreadConstraintMinDomains | quote }}
   ENABLE_SPILO_READINESS_PROBE: {{ .Values.postgreslet.enableSpiloReadinessProbe | quote  }}
+  ENABLE_KUBERNETES_USE_CONFIGMAPS: {{ .Values.postgreslet.enableKubernetesUseConfigMaps | quote  }}
 kind: ConfigMap
 metadata:
   name: {{ include "postgreslet.fullname" . }}

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -91,7 +91,7 @@ postgreslet:
   # postgresImageRepository
   postgresImageRepository: "containers.cybertec.at/f-i-ts/spilo-16"
   # postgresImageTag
-  postgresImageTag: "4.0_2026-01-19"
+  postgresImageTag: "4.0_2026-01-26"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: r.metal-stack.io/postgreslet
   pullPolicy: IfNotPresent
-  tag: "v0.23.0"
+  tag: "v0.25.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -87,11 +87,11 @@ postgreslet:
   # operatorImageRepository
   operatorImageRepository: "ghcr.io/zalando/postgres-operator"
   # operatorImageTag
-  operatorImageTag: "v1.14.0"
+  operatorImageTag: "v1.15.1"
   # postgresImageRepository
   postgresImageRepository: "containers.cybertec.at/f-i-ts/spilo-16"
   # postgresImageTag
-  postgresImageTag: "4.0_2025-10-27"
+  postgresImageTag: "4.0_2026-01-19"
   # etcdHost The connection string for Patroni defined as host:port. Not required when native Kubernetes support is used. The default is empty (use Kubernetes-native DCS).
   etcdHost: ""
   # enableCrdValidation  toggles if the operator will create or update CRDs with OpenAPI v3 schema validation
@@ -168,7 +168,7 @@ addRandomLabel: false
 sidecars:
   fluentbit:
     imageRepository: "cr.fluentbit.io/fluent/fluent-bit"
-    imageTag: "4.0.4"
+    imageTag: "4.2.2"
     resources:
       requests:
         cpu: "100m"

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -160,6 +160,8 @@ postgreslet:
   podTopologySpreadConstraintMinDomains: 0
   # enableSpiloReadinessProbe Tells to postgres-operator to enable or disable the built-in readinessProbe
   enableSpiloReadinessProbe: false
+  # enableKubernetesUseConfigMaps Enables or disables the kubernetes_use_configmaps in the postgres-operator configuration, needed for the migration from Endpoints to ConfigMaps (https://github.com/zalando/postgres-operator/pull/2961)
+  enableKubernetesUseConfigMaps: false
 
 # addRandomLabel adds a random label each time the deployment.yaml is rendered, forcing k8s to update that deployment.
 # In combination with image.PullPolicy=Always, this effetifely forces a reload of the pod, even if the image tag stays the same.

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: r.metal-stack.io/postgreslet
   pullPolicy: IfNotPresent
-  tag: "v0.25.0"
+  tag: "v0.26.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

Upgrade versions:

- Chart: 0.21.0
- Postgreslet: 0.25.0
- Postgres-Operator: 1.15.1
- Spilo-Image: spilo-16:4.0_2026-01-19
- Fluentbit-Image: 4.2.2