### PR TITLE
Postgreslet Next Release

### DIFF
--- a/charts/postgreslet/Chart.yaml
+++ b/charts/postgreslet/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.26.0"
+appVersion: "v0.27.0"

--- a/charts/postgreslet/templates/configmap.yaml
+++ b/charts/postgreslet/templates/configmap.yaml
@@ -69,6 +69,7 @@ data:
   POD_TOPOLOGY_SPREAD_CONSTRAINT_MIN_DOMAINS: {{ .Values.postgreslet.podTopologySpreadConstraintMinDomains | quote }}
   ENABLE_SPILO_READINESS_PROBE: {{ .Values.postgreslet.enableSpiloReadinessProbe | quote  }}
   ENABLE_KUBERNETES_USE_CONFIGMAPS: {{ .Values.postgreslet.enableKubernetesUseConfigMaps | quote  }}
+  SPILO_CPU_REQUESTS_PERCENTAGE: {{ .Values.postgreslet.spiloCpuRequestsPercentage | quote  }}
 kind: ConfigMap
 metadata:
   name: {{ include "postgreslet.fullname" . }}

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: r.metal-stack.io/postgreslet
   pullPolicy: IfNotPresent
-  tag: "v0.26.0"
+  tag: "v0.27.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -162,6 +162,8 @@ postgreslet:
   enableSpiloReadinessProbe: false
   # enableKubernetesUseConfigMaps Enables or disables the kubernetes_use_configmaps in the postgres-operator configuration, needed for the migration from Endpoints to ConfigMaps (https://github.com/zalando/postgres-operator/pull/2961)
   enableKubernetesUseConfigMaps: false
+    # spiloCpuRequestsPercentage The percentage of the CPU Requests compared to the CPU Limits, e.g. 50
+  spiloCpuRequestsPercentage: 50
 
 # addRandomLabel adds a random label each time the deployment.yaml is rendered, forcing k8s to update that deployment.
 # In combination with image.PullPolicy=Always, this effetifely forces a reload of the pod, even if the image tag stays the same.


### PR DESCRIPTION
## Description

* Postgreslet: Update image
* Postgreslet: Add config option for `resources.requests.cpu` relative to `resources.limits.cpu`


### Noteworthy

```NOTEWORTHY
The `resources.requests.cpu` is now set to 50% by default. To recreate the previous behaviour, set `postgreslet.spiloCpuRequestsPercentage` to `100`.
```
